### PR TITLE
Allow weights in `linear`

### DIFF
--- a/docs/src/generated/tutorial.jl
+++ b/docs/src/generated/tutorial.jl
@@ -68,7 +68,7 @@ AbstractPlotting.save("grouped_linear.svg", AbstractPlotting.current_scene()); n
 
 # ![](grouped_linear.svg)
 # This is a more complex example, where we split the scatter plot,
-# but do the linear regression with all the style. Instead we pass weights to `linear`
+# but do the linear regression with all the style. Moreover, we pass weights to `linear`
 # to compute the regression line with weighted least squares.
 
 different_grouping = grp * scat + linear * style(wts=:Hwy)

--- a/docs/src/generated/tutorial.jl
+++ b/docs/src/generated/tutorial.jl
@@ -68,9 +68,10 @@ AbstractPlotting.save("grouped_linear.svg", AbstractPlotting.current_scene()); n
 
 # ![](grouped_linear.svg)
 # This is a more complex example, where we split the scatter plot,
-# but do the linear regression with all the style.
+# but do the linear regression with all the style. Instead we pass weights to `linear`
+# to compute the regression line with weighted least squares.
 
-different_grouping = grp * scat + linear
+different_grouping = grp * scat + linear * style(wts=:Hwy)
 data(mpg) * cols * different_grouping |> draw
 AbstractPlotting.save("semi_grouped.svg", AbstractPlotting.current_scene()); nothing #hide
 

--- a/src/analysis/smooth.jl
+++ b/src/analysis/smooth.jl
@@ -1,10 +1,13 @@
 # From StatsMakie
 function _linear(x::AbstractVector{T}, y::AbstractVector;
-                 n_points = 100, interval = :confidence) where T
+                 n_points = 100, wts=T[],
+                 interval = length(wts) > 0 ? nothing : :confidence) where T
+    # Note: confidence interval are currently not supported for WLS in GLM.jl
     try
         y = collect(y)
         x = collect(x)
-        lin_model = GLM.lm([ones(T, length(x)) x], y)
+        wts = collect(wts)
+        lin_model = GLM.lm([ones(T, length(x)) x], y, wts=wts)
         x_min, x_max = extrema(x)
         x_new = range(x_min, x_max, length = n_points)
         pred = GLM.predict(lin_model,

--- a/src/analysis/smooth.jl
+++ b/src/analysis/smooth.jl
@@ -1,8 +1,8 @@
 # From StatsMakie
 function _linear(x::AbstractVector{T}, y::AbstractVector;
-                 n_points = 100, wts=T[],
+                 n_points = 100, wts = similar(x, 0),
                  interval = length(wts) > 0 ? nothing : :confidence) where T
-    # Note: confidence interval are currently not supported for WLS in GLM.jl
+    # Note: confidence intervals are currently not supported for WLS in GLM.jl
     try
         y = collect(y)
         x = collect(x)
@@ -11,12 +11,12 @@ function _linear(x::AbstractVector{T}, y::AbstractVector;
         x_min, x_max = extrema(x)
         x_new = range(x_min, x_max, length = n_points)
         pred = GLM.predict(lin_model,
-                                          [ones(T, n_points) x_new],
-                                          interval=interval)
+                           [ones(T, n_points) x_new],
+                           interval=interval)
         if !isnothing(interval)
-          y_new, lower, upper = pred
+            y_new, lower, upper = pred
         else
-          y_new = pred
+            y_new = pred
         end
         # the GLM predictions always return matrices
         x, y = x_new, vec(y_new)


### PR DESCRIPTION
With this PR one can pass weights to linear,

```julia
aog = data(df) * cols * style(wts=:pop2000) * linear)
```

GLM.jl has not yet implemented confidence intervals for weighted OLS.
Thus, I implemented specification of interval type `{:prediction, :confidence, nothing}` as well.  So one can do

```julia
aog = data(df) * cols * style(wts=:pop2000) * linear(interval=nothing)
```

now.

## Example

```julia
using AbstractPlotting, CairoMakie, MakieLayout, AlgebraOfGraphics
N = 150
x = rand(2N)
gx = rand(["x grp 1","x grp 2", "x grp 3"], 2N)
gy = rand(["y grp 1","y grp 2"], 2N)
wts = [fill(3, N); fill(0, N)]

df = DataFrame(x = x, y = x .+ wts .+ randn(2N), gx=gx, gy=gy, wts=wts)

cols = style(:x, :y);
grp = style(layout_x=:gx, layout_y=:gy)
scat = spec(Scatter)
pipeline1 = cols * (scat * style(color=:wts) + linear)
pipeline2 = cols * (scat * style(color=:wts) + linear(interval=nothing))
pipeline3 = cols * (scat * style(color=:wts) + style(wts=:wts) * linear)

data(df) * grp * pipeline1 |> draw
```
![linear1](https://user-images.githubusercontent.com/6280307/81177032-59abdd00-8fa6-11ea-88ae-928822656d23.png)

```julia
data(df) * grp * pipeline2 |> draw 
```
![linear2](https://user-images.githubusercontent.com/6280307/81177040-5b75a080-8fa6-11ea-8c9d-e7618c5b71cf.png)

```julia
data(df) * grp * pipeline3 |> draw 
```
![linear3](https://user-images.githubusercontent.com/6280307/81177055-5fa1be00-8fa6-11ea-8a01-2752f3184398.png)
