### PR TITLE
add Compat for AbstractPlotting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+AbstractPlotting = "0.11"
 GLM = "1"
 Loess = "0.5"
 NamedDims = "0.2"


### PR DESCRIPTION
v0.12 includes MakieLayout as submodule, but is not yet usable with CairoMakie.

In the meantime I propose to bind the version to 0.11