### PR TITLE
fix axis labels of single row and single column plots

### DIFF
--- a/src/draw.jl
+++ b/src/draw.jl
@@ -160,7 +160,7 @@ function spannable_xy_labels(layout)
         xlab = nothing
     end
     
-    # if layout has multiple row, check if xlabel is spannable
+    # if layout has multiple rows, check if xlabel is spannable
     if size(layout)[1] > 1
         unique_y_labs = unique(labs.y[.! labs.empty])
         ylab = length(unique_y_labs) == 1 ? only(unique_y_labs) : nothing
@@ -180,4 +180,3 @@ end
 layoutplot(; kwargs...) = t -> layoutplot(t; kwargs...)
 
 draw(args...; kwargs...) = layoutplot(args...; kwargs...)
-

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -152,12 +152,22 @@ function spannable_xy_labels(layout)
         (x = ax.xlabel[], y = ax.ylabel[], empty = isemptyax(ax))
     end |> StructArray
     
-    unique_x_labs = unique(labs.x[.! labs.empty])
-    unique_y_labs = unique(labs.y[.! labs.empty])
+    # if layout has multiple columns, check if xlabel is spannable
+    if size(layout)[2] > 1
+        unique_x_labs = unique(labs.x[.! labs.empty])
+        xlab = length(unique_x_labs) == 1 ? only(unique_x_labs) : nothing
+    else
+        xlab = nothing
+    end
     
-    xlab = length(unique_x_labs) == 1 ? only(unique_x_labs) : nothing
-    ylab = length(unique_y_labs) == 1 ? only(unique_y_labs) : nothing
-    
+    # if layout has multiple row, check if xlabel is spannable
+    if size(layout)[1] > 1
+        unique_y_labs = unique(labs.y[.! labs.empty])
+        ylab = length(unique_y_labs) == 1 ? only(unique_y_labs) : nothing
+    else
+        ylab = nothing
+    end
+        
     (x = xlab, y = ylab)
 end
 


### PR DESCRIPTION
This fixes a bug introduced in #54: for plots without layout_{x,y} the {x,y} label is not shown.

This is fixed now:

Case 1:
![facet0](https://user-images.githubusercontent.com/6280307/87861420-56d64c80-c946-11ea-88e2-0f329bee4378.png)

Case 2:
![facet1](https://user-images.githubusercontent.com/6280307/87861421-576ee300-c946-11ea-85b9-052d6492f98c.png)

Case 3:
![facet2](https://user-images.githubusercontent.com/6280307/87861422-58077980-c946-11ea-8ab7-8c5f77a793f7.png)

Case 4:
![facetx](https://user-images.githubusercontent.com/6280307/87861423-58077980-c946-11ea-8347-32e13b5bdd94.png)

Case 5:
![facety](https://user-images.githubusercontent.com/6280307/87861424-58a01000-c946-11ea-9388-39c81c36a66d.png)

