### PR TITLE
Padding of spanned axis labels

### DIFF
--- a/src/draw.jl
+++ b/src/draw.jl
@@ -160,7 +160,7 @@ function spannable_xy_labels(layout)
         xlab = nothing
     end
     
-    # if layout has multiple row, check if xlabel is spannable
+    # if layout has multiple rows, check if xlabel is spannable
     if size(layout)[1] > 1
         unique_y_labs = unique(labs.y[.! labs.empty])
         ylab = length(unique_y_labs) == 1 ? only(unique_y_labs) : nothing
@@ -180,4 +180,3 @@ end
 layoutplot(; kwargs...) = t -> layoutplot(t; kwargs...)
 
 draw(args...; kwargs...) = layoutplot(args...; kwargs...)
-

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -152,12 +152,22 @@ function spannable_xy_labels(layout)
         (x = ax.xlabel[], y = ax.ylabel[], empty = isemptyax(ax))
     end |> StructArray
     
-    unique_x_labs = unique(labs.x[.! labs.empty])
-    unique_y_labs = unique(labs.y[.! labs.empty])
+    # if layout has multiple columns, check if xlabel is spannable
+    if size(layout)[2] > 1
+        unique_x_labs = unique(labs.x[.! labs.empty])
+        xlab = length(unique_x_labs) == 1 ? only(unique_x_labs) : nothing
+    else
+        xlab = nothing
+    end
     
-    xlab = length(unique_x_labs) == 1 ? only(unique_x_labs) : nothing
-    ylab = length(unique_y_labs) == 1 ? only(unique_y_labs) : nothing
-    
+    # if layout has multiple row, check if xlabel is spannable
+    if size(layout)[1] > 1
+        unique_y_labs = unique(labs.y[.! labs.empty])
+        ylab = length(unique_y_labs) == 1 ? only(unique_y_labs) : nothing
+    else
+        ylab = nothing
+    end
+        
     (x = xlab, y = ylab)
 end
 


### PR DESCRIPTION
Instead of hard-coding the padding, the retrieves the padding from the individual panels, checks that they are all the same and use them.

Before:
![facetx](https://user-images.githubusercontent.com/6280307/87861888-ee3d9e80-c94a-11ea-84f7-b4dad3b84735.png)

After:
![facetx-after](https://user-images.githubusercontent.com/6280307/87861889-eed63500-c94a-11ea-9ce8-27158dfe8cb0.png)

I don't really know how to handle observables. If you want that the padding of the spanned labels listens to the padding of the individual panels, feel free to close this and use this commit in a separate PR.