### PR TITLE
Remove duplicated legends when grouping variable is used more than once

### DIFF
--- a/src/legend.jl
+++ b/src/legend.jl
@@ -34,6 +34,7 @@ function add_entry!(legend::Legend, entry::String; title::String="")
 end
 
 function create_legend(scene, legend::Legend)
+    legend = remove_duplicates(legend)
     sections = legend.sections
     MakieLayout.LLegend(
         scene,
@@ -42,3 +43,28 @@ function create_legend(scene, legend::Legend)
         getproperty.(sections, :title)
     )
 end
+
+function remove_duplicates(legend)
+    sections = legend.sections
+    titles = getproperty.(sections, :title)
+    # check if there are duplicate titles
+    unique_inds = unique_indices(titles)
+    has_duplicates = length(unique_inds) < length(titles)
+    # if so: remove duplicates, generate new names
+    if has_duplicates
+        sections_new = sections[unique_inds]
+    
+        names_new = map(unique_inds) do i
+            title = titles[i]
+            duplicate_inds = titles .== title
+            # ["var1", "var2"] becomes ["var1_var2"]
+            name = reduce((s,t) -> s * "_" * t, legend.names[duplicate_inds])
+        end
+        
+        return Legend(names_new, sections_new)
+    else
+        return legend
+    end
+end
+
+unique_indices(x) = findfirst.(isequal.(unique(x)), [x])

--- a/src/legend.jl
+++ b/src/legend.jl
@@ -67,8 +67,6 @@ function remove_duplicates(legend)
     end
 end
 
-unique_indices(x) = findfirst.(isequal.(unique(x)), [x])
-
 function unique_indices(x; keep)
     first_inds = indexin(x, x)
     inds_keep = findall(==(keep), x)

--- a/src/legend.jl
+++ b/src/legend.jl
@@ -70,8 +70,7 @@ end
 unique_indices(x) = findfirst.(isequal.(unique(x)), [x])
 
 function unique_indices(x; keep)
-    unique_inds = unique_indices(x)
+    first_inds = indexin(x, x)
     inds_keep = findall(==(keep), x)
     sort!(unique!([unique_inds; inds_keep]))
 end
-

--- a/src/legend.jl
+++ b/src/legend.jl
@@ -54,7 +54,6 @@ function remove_duplicates(legend)
     if has_duplicates
         sections_new = sections[unique_inds]
         names_new = legend.names[unique_inds]
-            
         return Legend(names_new, sections_new)
     else
         return legend

--- a/src/legend.jl
+++ b/src/legend.jl
@@ -48,7 +48,7 @@ function remove_duplicates(legend)
     sections = legend.sections
     titles = getproperty.(sections, :title)
     # check if there are duplicate titles
-    unique_inds = unique_indices(titles)
+    unique_inds = unique_indices(titles; keep = " ")
     has_duplicates = length(unique_inds) < length(titles)
     # if so: remove duplicates, generate new names
     if has_duplicates
@@ -68,3 +68,10 @@ function remove_duplicates(legend)
 end
 
 unique_indices(x) = findfirst.(isequal.(unique(x)), [x])
+
+function unique_indices(x; keep)
+    unique_inds = unique_indices(x)
+    inds_keep = findall(==(keep), x)
+    sort!(unique!([unique_inds; inds_keep]))
+end
+

--- a/src/legend.jl
+++ b/src/legend.jl
@@ -53,14 +53,8 @@ function remove_duplicates(legend)
     # if so: remove duplicates, generate new names
     if has_duplicates
         sections_new = sections[unique_inds]
-    
-        names_new = map(unique_inds) do i
-            title = titles[i]
-            duplicate_inds = titles .== title
-            # ["var1", "var2"] becomes ["var1_var2"]
-            name = reduce((s,t) -> s * "_" * t, legend.names[duplicate_inds])
-        end
-        
+        names_new = legend.names[unique_inds]
+            
         return Legend(names_new, sections_new)
     else
         return legend

--- a/src/legend.jl
+++ b/src/legend.jl
@@ -70,5 +70,5 @@ end
 function unique_indices(x; keep)
     first_inds = indexin(x, x)
     inds_keep = findall(==(keep), x)
-    sort!(unique!([unique_inds; inds_keep]))
+    sort!(union!(inds_keep, first_inds))
 end


### PR DESCRIPTION
Currently, if a grouping variable is used twice, this will produce two identical legends.

```julia
using RDatasets: dataset
using AlgebraOfGraphics, AbstractPlotting, CairoMakie
mpg = dataset("ggplot2", "mpg");
cols = style(:Displ, :Hwy);
grp = style(color = :Cyl => categorical, marker=:Cyl => categorical);
scat = spec(Scatter, markersize=10px)
pipeline = cols * scat
scn = data(mpg) * grp * pipeline |> draw
```

before:
![before](https://user-images.githubusercontent.com/6280307/88309692-f6148e80-cd0e-11ea-8490-39ce4ee286a3.png)

with this PR this doesn't happen any longer
![after](https://user-images.githubusercontent.com/6280307/88309690-f57bf800-cd0e-11ea-96e9-92c150e3df75.png)

probably the implementation is overkill. It seems (but I cannot prove) that the for a given grouping variable the legends are always identical. In that case a simple filtering would suffice.
