### PR TITLE
pad facet text, add rect stroke and brighten color for cleaner look

### DIFF
--- a/src/draw.jl
+++ b/src/draw.jl
@@ -37,9 +37,11 @@ function add_facet_labels!(scene, axs, layout_levels;
     for i in eachindex(lxl)
         pos = axis == :x ? (1, i, Top()) : (i, Nx, Right())
         facetlayout[pos...] = LRect(
-            scene, color = RGBAf0(0, 0, 0, 0.2), strokevisible=false
+            scene, color = :gray85, strokevisible = true
         ) 
-        facetlayout[pos...] = LText(scene, lxl[i], rotation = -positive_rotation)
+        facetlayout[pos...] = LText(scene, lxl[i],
+            rotation = -positive_rotation, padding = (3, 3, 3, 3)
+        )
     end
 
     # Shared xlabel


### PR DESCRIPTION
with the changes I just made to the axis spine and rect alignments in abstractplotting (still needs to be merged and tagged) I think this improves the look. the text padding is good so that larger letters like g y etc. don't touch the borders