### PR TITLE
no legend-entry for `group`

### DIFF
--- a/src/draw.jl
+++ b/src/draw.jl
@@ -140,7 +140,7 @@ function layoutplot!(scene, layout, ts::ElementOrList)
             name = get_name(v)
             val = strip_name(v)
             val isa CategoricalArray && get!(level_dict, k, levels(val))
-            if k ∉ (:layout_x, :layout_y, :side, :dodge) # position modifiers do not take part in the legend
+            if k ∉ (:layout_x, :layout_y, :side, :dodge, :group) # position modifiers do not take part in the legend
                 legendsection = add_entry!(legend, string(k); title=string(name))
                 # here `val` will often be a NamedDimsArray, so we call `only` below
                 entry = string(only(val))


### PR DESCRIPTION
This implements a feature of `ggplot2` that implements grouping without a legend entry.

Use case 1: You have a plot with many groups, but only some of them are interesting.
Use case 2: You want to plot many lines from long data, in the same color.

```julia
using DataFrames, AlgebraOfGraphics, CairoMakie, AbstractPlotting

grps = 1:15

df = mapreduce(vcat, grps) do (i_grp)
    rw_i = cumsum(rand(10)) .+ i_grp
    map(enumerate(rw_i)) do (t, x)
      (grp=i_grp, t=t, val=x)
    end
end |> DataFrame

data(df) * spec(Lines) * style(:t, :val, group=:grp) |> draw |> x -> save("/tmp/group1.png", x)
```
![group1](https://user-images.githubusercontent.com/6280307/92112141-a507b800-eded-11ea-9dec-a07ab8871369.png)

```julia

transform!(df, :grp => ByRow(x -> (8 <= x <= 10 ? x : "other")) => :highlight)

data(df) * spec(Lines) * style(:t, :val, group=:grp, color=:highlight) |> draw |> x -> save("/tmp/group1.png", x)
```

![group2](https://user-images.githubusercontent.com/6280307/92112163-ac2ec600-eded-11ea-9de6-ba707c26f384.png)
