### PR TITLE
Legends for continuously styled variables

### DIFF
--- a/src/AlgebraOfGraphics.jl
+++ b/src/AlgebraOfGraphics.jl
@@ -49,6 +49,7 @@ include("analysis/frequency.jl")
 include("analysis/histogram.jl")
 include("legend.jl")
 include("dodge.jl")
+include("colorbar.jl")
 include("draw.jl")
 
 end # module

--- a/src/colorbar.jl
+++ b/src/colorbar.jl
@@ -1,4 +1,6 @@
-function AbstractPlotting.MakieLayout.LColorbar(parent::Scene, plots::Vector{<: AbstractPlot}; kwargs...)
+import AbstractPlotting.MakieLayout.LColorbar
+
+function AbstractPlotting.MakieLayout.LColorbar(parent, plots::Vector{<: AbstractPlot}; kwargs...)
     colormap = plots[1].colormap
     # compute colorrange
     min = minimum(p.colorrange[][1] for p in plots)

--- a/src/colorbar.jl
+++ b/src/colorbar.jl
@@ -1,0 +1,16 @@
+function AbstractPlotting.MakieLayout.LColorbar(parent::Scene, plots::Vector{<: AbstractPlot}; kwargs...)
+    colormap = plots[1].colormap
+    # compute colorrange
+    min = minimum(p.colorrange[][1] for p in plots)
+    max = maximum(p.colorrange[][2] for p in plots)
+    colorrange = (min, max)
+     
+    for p in plots
+        p.colorrange = colorrange
+    end
+    
+    LColorbar(parent,
+        colormap = plots[1].colormap,
+        limits = colorrange;
+        kwargs...) 
+end

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -165,17 +165,24 @@ function layoutplot!(scene, layout, ts::ElementOrList)
             end
         end
     end
+    
+    legend_layout = layout[1, end+1] = GridLayout(tellheight = false)
+    
     if !isempty(legend.sections)
         try
-            layout[1, end+1] = create_legend(scene, legend)
+            leg = legend_layout[end+1, 1] = create_legend(scene, legend)
+            leg.framevisible[] = false
         catch e
             @warn "Automated legend was not possible due to $e"
         end
     end
     if length(for_colormap) > 0
         T = typeof(for_colormap[1])
-        layout[1,end+1] = MakieLayout.LColorbar(scene, T[for_colormap...], width=30, label = string(colorname))
+        cbar = legend_layout[end+1, 1] = MakieLayout.LColorbar(scene, T[for_colormap...], width=30, height=120)
+        legend_layout[end, 1, Top()] = LText(scene, string(colorname), padding = (10,10,10,10))
     end
+    
+    trim!(legend_layout)
     
     layout_x_levels = get(level_dict, :layout_x, nothing)
     layout_y_levels = get(level_dict, :layout_y, nothing)

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -109,6 +109,7 @@ function layoutplot!(scene, layout, ts::ElementOrList)
     hideydecorations!.(axs[:, 2:end], grid = false)
     
     for_colormap = []
+    colorname = nothing
     
     legend = Legend()
     level_dict = Dict{Symbol, Any}()
@@ -119,6 +120,7 @@ function layoutplot!(scene, layout, ts::ElementOrList)
         P isa Symbol && (P = getproperty(AbstractPlotting, P))
         args, kwargs = split(options)
         names, args = extract_names(args)
+        kwnames, _ = extract_names(kwargs)
         attrs = Attributes(kwargs)
         apply_alpha_transparency!(attrs)
         x_pos = pop!(attrs, :layout_x, 1) |> to_value |> rank
@@ -136,6 +138,11 @@ function layoutplot!(scene, layout, ts::ElementOrList)
         current = AbstractPlotting.plot!(ax, P, attrs, args...)
         if hasproperty(style.value, :color)
             push!(for_colormap, current)
+            if isnothing(colorname)
+                colorname = kwnames.color
+            else
+                @assert colorname == kwnames.color
+            end
         end
         set_axis_labels!(ax, names)
         set_axis_ticks!(ax, ticks)
@@ -165,7 +172,7 @@ function layoutplot!(scene, layout, ts::ElementOrList)
     end
     if length(for_colormap) > 0
         T = typeof(for_colormap[1])
-        layout[1,end+1] = MakieLayout.LColorbar(scene, T[for_colormap...], width=30)
+        layout[1,end+1] = MakieLayout.LColorbar(scene, T[for_colormap...], width=30, label = string(colorname))
     end
     
     layout_x_levels = get(level_dict, :layout_x, nothing)


### PR DESCRIPTION
Here is some refactoring of the legend creation to simplify adding legends for continuously styled variables.

It also includes a proof of concept for `markersize`. It builds on the `Colorbar` PR.

I guess the goal here is to find a general solution for continuous styles (`linewidth`, `alpha`, what else?)

![Screenshot 2020-09-25 at 18 13 16](https://user-images.githubusercontent.com/6280307/94290666-cece7d80-ff5a-11ea-8789-798ada43d7c7.png)

addresses #83 and (partially) #57  

```julia
using RDatasets: dataset
using AlgebraOfGraphics, AbstractPlotting, GLMakie
using AlgebraOfGraphics.MakieLayout

mpg = dataset("ggplot2", "mpg")
cols = style(:Displ, :Hwy)
grp = style(color = :Cyl => categorical)
mpg[!,:Group] = mpg.Cyl .> 6
mpg[!,:Color] = 3 .* rand.() .+ 2 .* mpg.Cyl 

aog2 = data(mpg) * style(:Displ, :Hwy, layout_x = :Drv, markersize = :Color,  marker = :Group => categorical, color = :Color) * spec(Scatter)

scene, layout = layoutscene()
 scat = AlgebraOfGraphics.layoutplot!(scene, layout, aog2)
```