### PR TITLE
use NamedDims unname to remove names

### DIFF
--- a/src/AlgebraOfGraphics.jl
+++ b/src/AlgebraOfGraphics.jl
@@ -3,7 +3,7 @@ module AlgebraOfGraphics
 using Tables: columns, getcolumn, columnnames, AbstractColumns, Tables
 using CategoricalArrays: categorical, cut, levelcode, refs, levels, CategoricalArray
 using Observables: AbstractObservable, Observable, to_value
-using NamedDims: NamedDimsArray, dimnames
+using NamedDims: NamedDimsArray, dimnames, unname
 using StructArrays: GroupPerm, refine_perm!, uniquesorted, fieldarrays, StructArray
 using KernelDensity: kde
 using StatsBase: fit, Histogram, weights, AbstractWeights, normalize, sturges, histrange

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,7 +43,7 @@ keyword(ps::NamedTuple) = last(split(ps))
 # naming utils
 
 get_name(v::NamedDimsArray) = dimnames(v)[1]
-strip_name(v::NamedDimsArray) = parent(v)
+strip_name(v::NamedDimsArray) = unname(v)
 get_name(v) = Symbol(" ")
 strip_name(v) = v
 


### PR DESCRIPTION
`unname` is the operation that semantically does this:
See:
https://github.com/invenia/NamedDims.jl/blob/942bb283c62dd64c0ca484bda19c1bb832f268fa/src/name_operations.jl#L45-L46

Under the hood it just calls `parent` but seem more semantic to use `unname`.
Potentially could just replace all uses of `strip_names` with `unname`