### PR TITLE
Rename types from AbstractPlotting.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-AbstractPlotting = "0.12.17, 0.13, 0.14"
+AbstractPlotting = "0.15"
 CategoricalArrays = "0.8"
 GLM = "1"
 GeometryBasics = "0.2, 0.3"

--- a/examples/gui.jl
+++ b/examples/gui.jl
@@ -20,7 +20,7 @@ function gui!(scene, layout, df)
     plot_options = [("none", nothing), ("scatter", Scatter), ("lines", Lines), ("barplot", BarPlot)]
     plot_menu = LMenu(scene, options = plot_options, textsize=30, width=500)
 
-    layout[1, 1] = LText(scene, "plot type", textsize=30)
+    layout[1, 1] = Label(scene, "plot type", textsize=30)
     layout[1, 2] = plot_menu
 
     analysis_options = [("none", nothing), ("linear", linear), ("smooth", smooth),
@@ -28,7 +28,7 @@ function gui!(scene, layout, df)
 
     analysis_menu = LMenu(scene, options = analysis_options, textsize=30, width=500)
 
-    layout[2, 1] = LText(scene, "analysis", textsize=30)
+    layout[2, 1] = Label(scene, "analysis", textsize=30)
     layout[2, 2] = analysis_menu
 
     axis_options = vcat([("None", nothing)], [(s, Symbol(s)) for s in propertynames(table.data)])
@@ -38,12 +38,12 @@ function gui!(scene, layout, df)
     N = length(mappings)
 
     for i in 1:N
-        layout[2+i, 1] = LText(scene, mappings[i], textsize=30)
+        layout[2+i, 1] = Label(scene, mappings[i], textsize=30)
         layout[2+i, 2] = mapping_menus[i]
     end
 
-    plot_button = LButton(scene, label="Plot", textsize=30)
-    add_and_plot_button = LButton(scene, label="Add and Plot", buttoncolor="powderblue", textsize=30)
+    plot_button = Button(scene, label="Plot", textsize=30)
+    add_and_plot_button = Button(scene, label="Add and Plot", buttoncolor="powderblue", textsize=30)
 
     layout[1, 3] = plot_button
     layout[1, 4] = add_and_plot_button

--- a/src/AlgebraOfGraphics.jl
+++ b/src/AlgebraOfGraphics.jl
@@ -23,9 +23,9 @@ using AbstractPlotting: Point2f0,
                         RGBAf0,
                         AbstractPlotting
 
-using AbstractPlotting.MakieLayout: LAxis,
-                                    LText,
-                                    LRect,
+using AbstractPlotting.MakieLayout: Axis,
+                                    Label,
+                                    Box,
                                     GridLayout,
                                     linkxaxes!,
                                     linkyaxes!,

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -36,10 +36,10 @@ function add_facet_labels!(scene, axs, layout_levels;
     lxl = string.(layout_levels)
     for i in eachindex(lxl)
         pos = axis == :x ? (1, i, Top()) : (i, Nx, Right())
-        facetlayout[pos...] = LRect(
+        facetlayout[pos...] = Box(
             scene, color = :gray85, strokevisible = true
         ) 
-        facetlayout[pos...] = LText(scene, lxl[i],
+        facetlayout[pos...] = Label(scene, lxl[i],
             rotation = -positive_rotation, padding = (3f0, 3f0, 3f0, 3f0)
         )
     end
@@ -57,7 +57,7 @@ function add_facet_labels!(scene, axs, layout_levels;
     end
 
     if !isnothing(spanned_label)
-        label = LText(scene, spanned_label, padding = padding, rotation = positive_rotation)
+        label = Label(scene, spanned_label, padding = padding, rotation = positive_rotation)
         pos = axis == :x ? (Ny, :, Bottom()) : (:, 1, Left())
         facetlayout[pos...] = label
     end
@@ -103,7 +103,7 @@ function layoutplot!(scene, layout, ts::ElementOrList)
         # dodge may need to be done separately per each subplot
         Ndodge = max(Ndodge, rank(to_value(get(spec.options, :dodge, Ndodge))))
     end
-    axs = facetlayout[1:Ny, 1:Nx] = [LAxis(scene) for i in 1:Ny, j in 1:Nx]
+    axs = facetlayout[1:Ny, 1:Nx] = [Axis(scene) for i in 1:Ny, j in 1:Nx]
     for i in 1:Nx
         linkxaxes!(axs[:, i]...)
     end

--- a/src/legend.jl
+++ b/src/legend.jl
@@ -36,11 +36,11 @@ end
 function create_legend(scene, legend::Legend)
     legend = remove_duplicates(legend)
     sections = legend.sections
-    MakieLayout.LLegend(
+    MakieLayout.Legend(
         scene,
         getproperty.(sections, :plots),
         getproperty.(sections, :names),
-        # LLegend needs `nothing` to remove the space for a missing title
+        # Legend needs `nothing` to remove the space for a missing title
         [isempty(t) ? nothing : t for t in getproperty.(sections, :title)]
     )
 end


### PR DESCRIPTION
AbstractPlotting renamed a bunch of things recently.
This change propagates those renames to AlgebraOfGraphics.