### PR TITLE
clarify tutorial fit grouping

### DIFF
--- a/docs/src/generated/penguins.jl
+++ b/docs/src/generated/penguins.jl
@@ -112,7 +112,7 @@ layers = linear() + mapping(col = :sex)
 plt = penguin_bill * layers * mapping(color = :species)
 draw(plt; axis)
 
-# See how both plots show the same fit, because the sex mapping is not applied
+# See how both plots show the same fit, because the `sex` mapping is not applied
 # to `linear()`. The following on the other hand produces a separate fit for
 # males and females:
 

--- a/docs/src/generated/penguins.jl
+++ b/docs/src/generated/penguins.jl
@@ -105,11 +105,19 @@ layers = linear() + mapping(marker = :sex)
 plt = penguin_bill * layers * mapping(color = :species)
 draw(plt; axis)
 
-# This plot is getting a little bit crowded. We could instead analyze female and
+# This plot is getting a little bit crowded. We could instead show female and
 # male penguins in separate subplots.
 
 layers = linear() + mapping(col = :sex)
 plt = penguin_bill * layers * mapping(color = :species)
+draw(plt; axis)
+
+# See how both plots show the same fit, because the sex mapping is not applied
+# to `linear()`. The following on the other hand produces a separate fit for
+# males and females:
+
+layers = linear() + mapping()
+plt = penguin_bill * layers * mapping(color = :species, col = :sex)
 draw(plt; axis)
 
 # ## Smooth density plots
@@ -161,7 +169,7 @@ draw(plt; axis)
 
 # ## Correlating three variables
 #
-# We are now mostly up to speed with `bill` size, but we have not consider how
+# We are now mostly up to speed with `bill` size, but we have not considered how
 # it relates to other penguin features, such as their weight.
 # For that, a possible approach is to use a continuous color
 # on a gradient to denote weight and different marker shapes to denote species.


### PR DESCRIPTION
The penguin tutorial shows linear fits on female and male plots using

```julia
layers = linear() + mapping(col = :sex)
plt = penguin_bill * layers * mapping(color = :species)
draw(plt; axis)
```

![image](https://user-images.githubusercontent.com/2412819/118657301-a64a0b00-b7eb-11eb-921d-4c68d84d259a.png)

The sex mapping is applied only to the scatter so the same fit is shown left and right. Is this intentional? This PR first shows a specific fit for each sex:

```julia
layers = linear() + mapping()
plt = penguin_bill * layers * mapping(color = :species, col = :sex)
draw(plt; axis)
```

![image](https://user-images.githubusercontent.com/2412819/118657723-02ad2a80-b7ec-11eb-97ab-bd9410cca411.png)

then shows how to pool data from both sexes (i.e showing the original code).