### PR TITLE
all data entries must be equal when merging labels

### DIFF
--- a/src/algebra/processing.jl
+++ b/src/algebra/processing.jl
@@ -17,7 +17,14 @@ function shape(x::Union{Entry, Layer})
     return Broadcast.combine_axes(arrays...)
 end
 
-assert_equal(a, b) = (@assert(isequal(a, b)); a)
+function assert_equal(a, b)
+    if !isequal(a, b)
+        msg = "$a and $b must be equal"
+        throw(ArgumentError(msg))
+    end
+    return a
+end
+
 getuniquevalue(v) = reduce(assert_equal, v)
 
 haszerodims(::AbstractArray) = false

--- a/src/guides/legend.jl
+++ b/src/guides/legend.jl
@@ -91,8 +91,8 @@ function _Legend_(fg::FigureGrid)
 
     for title in titles
         label_attrs = [key for (key, val) in labels if val == title]
-        first_scale = scales[first(label_attrs)]
-        elements = map(eachindex(first_scale.data)) do idx
+        uniquevalues = mapreduce(k -> scales[k].data, assert_equal, label_attrs)
+        elements = map(eachindex(uniquevalues)) do idx
             local elements = LegendElement[]
             for (P, attrs) in zip(plottypes, attributes)
                 shared_attrs = attrs ∩ label_attrs
@@ -102,7 +102,7 @@ function _Legend_(fg::FigureGrid)
             end
             return elements
         end
-        push!(labels_list, map(string, first_scale.data))
+        push!(labels_list, map(string, uniquevalues))
         push!(elements_list, elements)
     end
     return elements_list, labels_list, nonemptytitles

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using AlgebraOfGraphics, Test
+using AlgebraOfGraphics, Makie, Test
 
 @testset "utils" begin
     v1 = [1, 2, 7, 11]
@@ -140,4 +140,13 @@ end
 
     @test string(nonnumeric(1)) == "1"
     @test isless(nonnumeric(1), nonnumeric(2))
+end
+
+@testset "legend_merging" begin
+    mwe_data = (; t = 1:20, y1 = ones(20), y2 = rand(20))
+    mwe_names = ["f_n", "f_d"]
+    plt = data(mwe_data) *
+        mapping("t", ["y1", "y2"] .=> "y"; color = dims(1) => (i -> mwe_names[i]), marker=dims(1)) *
+        (visual(Lines) + visual(Scatter))
+    @test_throws ArgumentError draw(plt)
 end


### PR DESCRIPTION
Fix #197 
