### PR TITLE
support renaming dims selector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraOfGraphics"
 uuid = "cbdf2221-f076-402e-a563-3d30da359d67"
 authors = ["Pietro Vertechi <pietro.vertechi@veos.digital>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/docs/src/generated/gallery.jl
+++ b/docs/src/generated/gallery.jl
@@ -217,7 +217,7 @@ labels = ["Trace 1", "Trace 2", "Trace 3"]
 plt = data(df) *
     density() *
     mapping([:a, :b, :c] .=> "some label") *
-    mapping(color=dims(1) => c -> labels[c])
+    mapping(color=dims(1) => renamer(labels))
 draw(plt)
 
 #
@@ -225,7 +225,7 @@ draw(plt)
 df = (a=rand(100), b=rand(100), c=rand(100), d=rand(100))
 labels = ["Trace 1", "Trace 2", "Trace 3"]
 layers = linear() + visual(Scatter)
-plt = data(df) * layers * mapping(1, 2:4 .=> "value", color=dims(1) => c -> labels[c])
+plt = data(df) * layers * mapping(1, 2:4 .=> "value", color=dims(1) => renamer(labels))
 draw(plt)
 
 # The wide format is combined with broadcast semantics.
@@ -247,7 +247,7 @@ z = cumsum(randn(length(x)))
 df = (; x, y, z)
 labels = ["series 1", "series 2", "series 3", "series 4", "series 5"]
 plt = data(df) *
-    mapping(:x, [:y, :z] .=> "value", color=dims(1) => (c -> labels[c]) => "series ") *
+    mapping(:x, [:y, :z] .=> "value", color=dims(1) => renamer(labels) => "series ") *
     visual(Lines)
 draw(plt)
 
@@ -258,7 +258,7 @@ y = cumsum(randn(length(x)))
 z = cumsum(randn(length(x)))
 df = (; x, y, z)
 plt = data(df) *
-    mapping(:x, [:y, :z] .=> "value", color=dims(1) => (c -> labels[c])=>"series ") *
+    mapping(:x, [:y, :z] .=> "value", color=dims(1) => renamer(labels)=>"series ") *
     visual(Lines)
 draw(plt)
 
@@ -323,7 +323,7 @@ draw(m)
 
 #
 
-m = mapping(x, [y z], color=dims(1) => c -> ["a", "b", "c"][c])
+m = mapping(x, [y z], color=dims(1) => renamer(["a", "b", "c"]))
 draw(m)
 
 #

--- a/docs/src/generated/gallery.jl
+++ b/docs/src/generated/gallery.jl
@@ -258,7 +258,7 @@ y = cumsum(randn(length(x)))
 z = cumsum(randn(length(x)))
 df = (; x, y, z)
 plt = data(df) *
-    mapping(:x, [:y, :z] .=> "value", color=dims(1) => renamer(labels)=>"series ") *
+    mapping(:x, [:y, :z] .=> "value", color=dims(1) => renamer(labels) =>"series ") *
     visual(Lines)
 draw(plt)
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -15,6 +15,8 @@ struct Renamer{U, L}
     labels::L
 end
 
+(r::Renamer{Nothing})(x) = r.labels[x]
+
 function (r::Renamer)(x)
     for i in keys(r.uniquevalues)
         cand = @inbounds r.uniquevalues[i]
@@ -26,16 +28,49 @@ function (r::Renamer)(x)
     throw(KeyError(x))
 end
 
-"""
-    renamer(ps::Pair...)
+renamer(args::Pair...) = renamer(args)
 
-Utility to rename a categorical variable, as in `renamer(value1 => label1, value2 => label2)`.
-The keys of all pairs should be all the unique values of the categorical variable and
-the values should be the corresponding labels. The order of `ps` is respected in
-the legend.
 """
-function renamer(ps::Pair...)
-    k, v = map(first, ps), map(last, ps)
+    renamer(arr::Union{AbstractArray, Tuple})
+
+Utility to rename a categorical variable, as in `renamer([value1 => label1, value2 => label2])`.
+The keys of all pairs should be all the unique values of the categorical variable and
+the values should be the corresponding labels. The order of `arr` is respected in
+the legend.
+
+# Examples
+```jldoctest
+julia> r = renamer(["class 1" => "Class One", "class 2" => "Class Two"])
+AlgebraOfGraphics.Renamer{Vector{String}, Vector{String}}(["class 1", "class 2"], ["Class One", "Class Two"])
+
+julia> println(r("class 1"))
+Class One
+```
+Alternatively, a sequence of pair arguments may be passed.
+```jldoctest
+julia> r = renamer("class 1" => "Class One", "class 2" => "Class Two")
+AlgebraOfGraphics.Renamer{Tuple{String, String}, Tuple{String, String}}(("class 1", "class 2"), ("Class One", "Class Two"))
+
+julia> println(r("class 1"))
+Class One
+```
+
+If `arr` does not contain `Pair`s, elements of `arr` are assumed to be labels, and the
+unique values of the categorical variable are taken to be the indices of the array.
+This is particularly useful for `dims` mappings.
+
+# Examples
+```jldoctest
+julia> r = renamer(["Class One", "Class Two"])
+AlgebraOfGraphics.Renamer{Nothing, Vector{String}}(nothing, ["Class One", "Class Two"])
+
+julia> println(r(2))
+Class Two
+```
+"""
+function renamer(arr::ArrayLike)
+    ispairs = all(x -> isa(x, Pair), arr)
+    k, v = ispairs ? (map(first, arr), map(last, arr)) : (nothing, arr)
     return Renamer(k, v)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ end
 
 @testset "process_mappings" begin
     df = (x=rand(1000), y=rand(1000), z=rand(1000), c=rand(["a", "b", "c"], 1000))
-    d = mapping(:x => exp, [:y, :z], color=:c, marker = dims(1) => t -> ["a", "b"][t])
+    d = mapping(:x => exp, [:y, :z], color=:c, marker = dims(1) => renamer(["a", "b"]))
     layer = data(df) * d
     entry = AlgebraOfGraphics.process_mappings(layer)
     @test entry.positional[1] == fill(map(exp, df.x))


### PR DESCRIPTION
Fixes #197 (for real this time). Allow `renamer(labels)` to rename a `dims` mapping while preserving the order.