### PR TITLE
Update documentation for density

### DIFF
--- a/src/transformations/density.jl
+++ b/src/transformations/density.jl
@@ -37,8 +37,9 @@ function (d::DensityAnalysis)(le::Entry)
 end
 
 """
-    density(; extrema, npoints, kernel, bandwidth)
+    density(; datalimits, npoints, kernel, bandwidth)
 
 Fit a kernel density estimation of `data`.
+For example, use `datalimits=((0.0, 60.0), )` to calculate the density from 0 to 60 on the x-axis.
 """
 density(; kwargs...) = Layer((DensityAnalysis(; kwargs...),))


### PR DESCRIPTION
As far as I understand, using `datalimits` is the only way to set the density range; I couldn't get it to work with `extrema`. 

This PR is just a temporary clarification. Maybe something with a `jldoctest` is better depending on how stable you expect this part of the code to be :)