### PR TITLE
Replace Point2f0 with Point2f

### DIFF
--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -1,4 +1,4 @@
-to_points(ring) = map(Point2f0, ring)
+to_points(ring) = map(Point2f, ring)
 
 function to_polygon(rings)
     exterior, interiors... = map(to_points, rings)

--- a/src/guides/legendelements.jl
+++ b/src/guides/legendelements.jl
@@ -2,7 +2,7 @@ from_default_theme(attr) = Makie.current_default_theme()[attr]
 
 function legend_elements(::Type{Scatter};
                          marker=from_default_theme(:marker),
-                         markerpoints=[Point2f0(0.5, 0.5)],
+                         markerpoints=[Point2f(0.5, 0.5)],
                          color=from_default_theme(:markercolor),
                          kwargs...)
     return [MarkerElement(; marker, markerpoints, markercolor=color, kwargs...)]


### PR DESCRIPTION
This switches to new GeometryBasics type names from JuliaGeometry/GeometryBasics.jl#97.