### PR TITLE
Remove Axis(ae)

### DIFF
--- a/docs/src/generated/gallery.jl
+++ b/docs/src/generated/gallery.jl
@@ -77,7 +77,7 @@ plt = data(df) * mapping(:x, :y, col=:i, row=:j)
 subfig = fig[1, 2:3]
 ag = draw!(subfig, plt)
 for ae in ag
-    Axis(ae).xticklabelrotation[] = π/2
+    ae.axis.xticklabelrotation[] = π/2
 end
 fig
 

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -119,7 +119,7 @@ function compute_axes_grid(fig, s::OneOrMoreLayers;
             label = compute_label(ae.entries, i)
             for (k′, v) in pairs((label=string(label), ticks=ticks(scale)))
                 k = Symbol(var, k′)
-                k in keys(axis) || (getproperty(Axis(ae), k)[] = v)
+                k in keys(axis) || (getproperty(ae.axis, k)[] = v)
             end
         end
     end

--- a/src/entries.jl
+++ b/src/entries.jl
@@ -46,8 +46,6 @@ struct AxisEntries
     scales::Dict{KeyType, Any}
 end
 
-Makie.Axis(ae::AxisEntries) = ae.axis
-
 # Slightly complex machinery to recombine stacked barplots
 function mergeable(e1::Entry, e2::Entry)
     for e in (e1, e2)


### PR DESCRIPTION
This removes the `Makie.Axis(ae::AxisEntries) = ae.axis` definition: it seems misleading to me as `Makie.Axis` is a constructor, and this is a getter.

I was confused when reading the example at http://juliaplots.org/AlgebraOfGraphics.jl/dev/generated/gallery/#Embedding-facets:  `Axis` was first used to create the axis on the left and that made sense, but I didn't understand why an axis was later created for each facet when rotating the label.

Using the `axis` field also seems consistent with the Makie API and the `figure` field advertised at http://juliaplots.org/AlgebraOfGraphics.jl/dev/FAQs/#How-to-combine-AlgebraOfGraphics-with-plain-Makie-plots.