### PR TITLE
Improve `facet_wrap`; Introduce `linkxaxes`, `linkyaxes` for `facet_wrap` and `facet_grid`

### DIFF
--- a/docs/gallery/gallery/layout/faceting.jl
+++ b/docs/gallery/gallery/layout/faceting.jl
@@ -14,11 +14,19 @@ df = (x=rand(100), y=rand(100), i=rand(["a", "b", "c"], 100), j=rand(["d", "e", 
 plt = data(df) * mapping(:x, :y, col=:i, row=:j)
 draw(plt)
 
+# ## Facet grid unlinked axes
+
+draw(plt, facet = (; linkxaxes = false))
+
 # ## Facet wrap
 
 df = (x=rand(100), y=rand(100), l=rand(["a", "b", "c", "d", "e"], 100))
 plt = data(df) * mapping(:x, :y, layout=:l)
 draw(plt)
+
+# ## Facet wrap with unlinked axes
+
+draw(plt, facet = (; linkxaxes = false, linkyaxes = false))
 
 # ## Adding traces to only some subplots
 

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -169,9 +169,9 @@ Legend and colorbar are drawn automatically. For finer control, use [`draw!`](@r
 [`legend!`](@ref), and [`colorbar!`](@ref) independently.
 """
 function draw(s::OneOrMoreLayers;
-              axis = NamedTuple(), figure=NamedTuple(), palettes=NamedTuple())
+              axis = NamedTuple(), figure=NamedTuple(), palettes=NamedTuple(), facet=NamedTuple())
     fg = plot(s; axis, figure, palettes)
-    facet!(fg)
+    facet!(fg; facet...)
     colorbar!(fg)
     legend!(fg)
     resizetocontent!(fg)
@@ -187,8 +187,8 @@ The output can be customized by giving axis attributes to `axis` or custom palet
 to `palettes`.  
 """
 function draw!(fig, s::OneOrMoreLayers;
-               axis=NamedTuple(), palettes=NamedTuple())
+               axis=NamedTuple(), palettes=NamedTuple(), facet=NamedTuple())
     ag = plot!(fig, s; axis, palettes)
-    facet!(fig, ag)
+    facet!(fig, ag; facet...)
     return ag
 end

--- a/src/facet.jl
+++ b/src/facet.jl
@@ -122,11 +122,13 @@ end
 
 function consistent_xlabels(nonempty_aes)
     ax = first(nonempty_aes).axis
+    ax isa Axis3 && return false
     return all(ae -> ae.axis.xlabel[] == ax.xlabel[], nonempty_aes)
 end
 
 function consistent_ylabels(nonempty_aes)
     ax = first(nonempty_aes).axis
+    ax isa Axis3 && return false
     return all(ae -> ae.axis.ylabel[] == ax.ylabel[], nonempty_aes)
 end
 

--- a/src/facet.jl
+++ b/src/facet.jl
@@ -18,11 +18,12 @@ function facet_wrap!(fig, aes::AbstractMatrix{AxisEntries}; linkxaxes = true, li
 
     # span axis labels if appropriate
     nonempty_aes = get_nonempty_aes(aes)
+    is2d = isaxis2d(first(nonempty_aes))
 
-    if consistent_ylabels(nonempty_aes)
+    if is2d && consistent_ylabels(nonempty_aes)
         span_ylabel!(fig, aes)
     end
-    if consistent_xlabels(nonempty_aes)
+    if is2d && consistent_xlabels(nonempty_aes)
         span_xlabel!(fig, aes)
     end
     
@@ -41,13 +42,14 @@ function facet_grid!(fig, aes::AbstractMatrix{AxisEntries}; linkxaxes = true, li
 
     # span axis labels if appropriate
     nonempty_aes = get_nonempty_aes(aes)
-    
+    is2d = isaxis2d(first(nonempty_aes))
+
     if !isnothing(row_scale) && consistent_ylabels(nonempty_aes)
-        span_ylabel!(fig, aes)
+        is2d && span_ylabel!(fig, aes)
         row_labels!(fig, aes, row_scale)
     end
     if !isnothing(col_scale) && consistent_xlabels(nonempty_aes)
-        span_xlabel!(fig, aes)
+        is2d && span_xlabel!(fig, aes)
         col_labels!(fig, aes, col_scale)
     end
     return
@@ -122,13 +124,11 @@ end
 
 function consistent_xlabels(nonempty_aes)
     ax = first(nonempty_aes).axis
-    ax isa Axis3 && return false
     return all(ae -> ae.axis.xlabel[] == ax.xlabel[], nonempty_aes)
 end
 
 function consistent_ylabels(nonempty_aes)
     ax = first(nonempty_aes).axis
-    ax isa Axis3 && return false
     return all(ae -> ae.axis.ylabel[] == ax.ylabel[], nonempty_aes)
 end
 

--- a/src/facet.jl
+++ b/src/facet.jl
@@ -4,6 +4,11 @@ function facet_wrap!(fig, aes::AbstractMatrix{AxisEntries})
     scale = get(aes[1].scales, :layout, nothing)
     isnothing(scale) && return
     linkaxes!(aes...)
+
+    # delete empty axes
+    deleteemptyaxes!(aes)
+
+    # add facet labels
     for ae in aes
         ax = ae.axis
         entries = ae.entries
@@ -12,106 +17,160 @@ function facet_wrap!(fig, aes::AbstractMatrix{AxisEntries})
             (get(entry.primary, :layout, nothing) for entry in entries)
         )
         it = iterate(vs)
-        if isnothing(it)
-            delete!(ax)
-        else
+        if !isnothing(it)
             v, _ = it
             ax.title[] = string(v)
         end
     end
+    
     return
 end
-
-# F. Greimel implementation from AlgebraOfGraphics
 
 # TODO: add configuration options here (esp. to determine when / how to link)
 function facet_grid!(fig, aes::AbstractMatrix{AxisEntries})
     M, N = size(aes)
     row_scale, col_scale = map(sym -> get(aes[1].scales, sym, nothing), (:row, :col))
     all(isnothing, (row_scale, col_scale)) && return
+
+    # Link axes and hide decorations if appropriate
     hideinnerdecorations!(aes)
     linkaxes!(aes...)
 
-    nonempty_aes = filter(ae -> !isempty(ae.entries), aes)
-
-    ax = first(nonempty_aes).axis
-    titlegap = ax.titlegap
-    titlecolor = ax.titlecolor
-    titlefont = ax.titlefont
-    titlesize = ax.titlesize
-    facetlabelattributes = (
-        color=titlecolor,
-        font=titlefont,
-        textsize=titlesize,
-    )
-
-    consistent_xlabels = all(ae -> ae.axis.xlabel[] == ax.xlabel[], nonempty_aes)
-    consistent_ylabels = all(ae -> ae.axis.ylabel[] == ax.ylabel[], nonempty_aes)
-
-    if !isnothing(row_scale) && consistent_ylabels
-        for ae in aes
-            ae.axis.ylabelvisible[] = false
-        end
-        row_dict = Dict(zip(plotvalues(row_scale), datavalues(row_scale)))
-        facetlabelpadding = lift(titlegap) do gap
-            return (gap, 0f0, 0f0, 0f0)
-        end
-        for m in 1:M
-            Label(fig[m, N, Right()], string(row_dict[m]);
-                rotation=-π/2, padding=facetlabelpadding,
-                facetlabelattributes...)
-        end
-        protrusion = lift(
-            (xs...) -> maximum(x -> x.left, xs),
-            (MakieLayout.protrusionsobservable(ae.axis) for ae in aes[:, 1])...
-        )
-        # TODO: here and below, set in such a way that one can change padding after the fact?
-        ylabelpadding = lift(protrusion, ax.ylabelpadding) do val, p
-            return (0f0, val + p, 0f0, 0f0)
-        end
-        ylabelcolor = ax.ylabelcolor
-        ylabelfont = ax.ylabelfont
-        ylabelsize = ax.ylabelsize
-        ylabelattributes = (
-            color=ylabelcolor,
-            font=ylabelfont,
-            textsize=ylabelsize,
-        )
-        Label(fig[:, 1, Left()], ax.ylabel;
-            rotation=π/2, padding=ylabelpadding, ylabelattributes...)
+    # span axis labels if appropriate
+    nonempty_aes = get_nonempty_aes(aes)
+    
+    if !isnothing(row_scale) && consistent_ylabels(nonempty_aes)
+        span_ylabel!(fig, aes)
+        row_labels!(fig, aes, row_scale)
     end
-    if !isnothing(col_scale) && consistent_xlabels
-        for ae in aes
-            ae.axis.xlabelvisible[] = false
-        end
-        col_dict = Dict(zip(plotvalues(col_scale), datavalues(col_scale)))
-        labelpadding = lift(titlegap) do gap
-            return (0f0, 0f0, gap, 0f0)
-        end
-        for n in 1:N
-            Label(fig[1, n, Top()], string(col_dict[n]);
-                padding=labelpadding, facetlabelattributes...)
-        end
-        protrusion = lift(
-            (xs...) -> maximum(x -> x.bottom, xs),
-            (MakieLayout.protrusionsobservable(ae.axis) for ae in aes[M, :])...
-        )
-        xlabelpadding = lift(protrusion, ax.xlabelpadding) do val, p
-            return (0f0, 0f0, 0f0, val + p)
-        end
-        xlabelcolor = ax.xlabelcolor
-        xlabelfont = ax.xlabelfont
-        xlabelsize = ax.xlabelsize
-        xlabelattributes = (
-            color=xlabelcolor,
-            font=xlabelfont,
-            textsize=xlabelsize,
-        )
-        Label(fig[M, :, Bottom()], ax.xlabel;
-            padding=xlabelpadding, xlabelattributes...)
+    if !isnothing(col_scale) && consistent_xlabels(nonempty_aes)
+        span_xlabel!(fig, aes)
+        col_labels!(fig, aes, col_scale)
     end
     return
 end
+
+# facet labels
+
+function col_labels!(fig, aes, col_scale)
+    M, N = size(aes)
+    
+    ax = first_nonempty_axis(aes)
+    titlegap = ax.titlegap
+    
+    facetlabelattributes = (
+        color=ax.titlecolor,
+        font=ax.titlefont,
+        textsize=ax.titlesize,
+    )
+    
+    col_dict = Dict(zip(plotvalues(col_scale), datavalues(col_scale)))
+    labelpadding = lift(titlegap) do gap
+        return (0f0, 0f0, gap, 0f0)
+    end
+    for n in 1:N
+        Label(fig[1, n, Top()], string(col_dict[n]);
+        padding=labelpadding, facetlabelattributes...)
+    end
+
+end
+
+function row_labels!(fig, aes, row_scale)
+    M, N = size(aes)
+
+    ax = first_nonempty_axis(aes)
+    titlegap = ax.titlegap
+
+    facetlabelattributes = (
+        color=ax.titlecolor,
+        font=ax.titlefont,
+        textsize=ax.titlesize,
+    )
+    
+    row_dict = Dict(zip(plotvalues(row_scale), datavalues(row_scale)))
+    facetlabelpadding = lift(titlegap) do gap
+        return (gap, 0f0, 0f0, 0f0)
+    end
+    for m in 1:M
+        Label(fig[m, N, Right()], string(row_dict[m]);
+            rotation=-π/2, padding=facetlabelpadding,
+            facetlabelattributes...)
+    end
+end
+
+# spanned axis labels
+
+function consistent_xlabels(nonempty_aes)
+    ax = first(nonempty_aes).axis
+    return all(ae -> ae.axis.xlabel[] == ax.xlabel[], nonempty_aes)
+end
+
+function consistent_ylabels(nonempty_aes)
+    ax = first(nonempty_aes).axis
+    return all(ae -> ae.axis.ylabel[] == ax.ylabel[], nonempty_aes)
+end
+
+function span_xlabel!(fig, aes)
+    M, N = size(aes)
+    
+    for ae in aes
+        ae.axis.xlabelvisible[] = false
+    end
+    protrusion = lift(
+        (xs...) -> maximum(x -> x.bottom, xs),
+        (MakieLayout.protrusionsobservable(ae.axis) for ae in aes[M, :])...
+    )
+
+    ax = first_nonempty_axis(aes)
+    
+    xlabelpadding = lift(protrusion, ax.xlabelpadding) do val, p
+        return (0f0, 0f0, 0f0, val + p)
+    end
+    xlabelcolor = ax.xlabelcolor
+    xlabelfont = ax.xlabelfont
+    xlabelsize = ax.xlabelsize
+    xlabelattributes = (
+        color=xlabelcolor,
+        font=xlabelfont,
+        textsize=xlabelsize,
+    )
+    Label(fig[M, :, Bottom()], ax.xlabel;
+        padding=xlabelpadding, xlabelattributes...)
+end
+
+function span_ylabel!(fig, aes)
+    M, N = size(aes)
+    
+    for ae in aes
+        ae.axis.ylabelvisible[] = false
+    end
+    
+    protrusion = lift(
+        (xs...) -> maximum(x -> x.left, xs),
+        (MakieLayout.protrusionsobservable(ae.axis) for ae in aes[:, 1])...
+    )
+    # TODO: here and below, set in such a way that one can change padding after the fact?
+    ax = first_nonempty_axis(aes)
+    
+    ylabelpadding = lift(protrusion, ax.ylabelpadding) do val, p
+        return (0f0, val + p, 0f0, 0f0)
+    end
+    
+    ylabelcolor = ax.ylabelcolor
+    ylabelfont = ax.ylabelfont
+    ylabelsize = ax.ylabelsize
+    ylabelattributes = (
+        color=ylabelcolor,
+        font=ylabelfont,
+        textsize=ylabelsize,
+    )
+    Label(fig[:, 1, Left()], ax.ylabel;
+        rotation=π/2, padding=ylabelpadding, ylabelattributes...)
+end
+
+empty_ae(ae) = isempty(ae.entries)
+get_nonempty_aes(aes) = filter(!empty_ae, aes)
+first_nonempty_axis(aes) = first(get_nonempty_aes(aes)).axis
 
 function facet!(fig, aes::AbstractMatrix{AxisEntries})
     facet_wrap!(fig, aes)


### PR DESCRIPTION
<s> Implements #203 </s> (see https://github.com/JuliaPlots/AlgebraOfGraphics.jl/pull/285#issuecomment-933471969)

Example:

<details> <summary> Code </summary>

```julia
# ╔═╡ de609488-23c4-11ec-10b6-dbf425a6bbe8
begin
	using Pkg
	Pkg.develop("AlgebraOfGraphics")
	Pkg.add("CairoMakie")

	using AlgebraOfGraphics, CairoMakie
end

# ╔═╡ a8f90b4a-d4fb-48c7-8238-b039e4196dea
dta = let
	N = 100
	x = rand(1:10, N)
	(;
		x, 
		y = x .+ 2 .* rand.(),
		c = rand(["a", "b", "c"], N),
		d = rand(["α", "β"], N)
	)
end

# ╔═╡ 3cbdd2e7-343e-4f62-9c35-582647cf1a5d
plt = data(dta) * visual(Scatter) * mapping(
		:x, :y, color = :c,
		layout = :c
)

# ╔═╡ ad438c1c-3478-41ad-a138-05ac1b5f3288
begin
	linkxaxes = false
	linkyaxes = false #false
	facet = (; linkxaxes, linkyaxes)

	draw(plt; facet)
end
```

</details>


https://user-images.githubusercontent.com/6280307/135813480-40f82f4b-0155-4ccb-8f43-630558a4eb68.mov

<s> I haven't changed the `draw` function yet. </s>