### PR TITLE
Support LaTeX axis labels

### DIFF
--- a/docs/gallery/gallery/data manipulations/new_columns_on_the_fly.jl
+++ b/docs/gallery/gallery/data manipulations/new_columns_on_the_fly.jl
@@ -1,5 +1,5 @@
 # ---
-# title: New columns on the fly
+# title: Renaming (including LaTeX labels) and transforming variables
 # cover: assets/new_columns_on_the_fly.png
 # description: Transforming data before generating the plot
 # author: "[Pietro Vertechi](https://github.com/piever)"
@@ -8,11 +8,15 @@
 using AlgebraOfGraphics, CairoMakie
 set_aog_theme!() #src
 
-# Use a `Tuple` to pass combine several columns into a unique operation.
-
 df = (x=rand(100), y=rand(100), z=rand(100), c=rand(["a", "b"], 100))
 layers = linear() + mapping(color=:z)
-plt = data(df) * layers * mapping(:x, (:x, :y, :z) => (+) => "x + y + z", layout=:c)
+
+plt = data(df) * layers * mapping(:x => (x -> x^2) => L"x^2", :y => L"This variable is called $y$")
+fg = draw(plt)
+
+# Use a `Tuple` to pass combine several columns into a unique operation.
+
+plt = data(df) * layers * mapping(:x, (:x, :y, :z) => (+) => L"the new variable $x + y + z$", layout=:c)
 fg = draw(plt)
 
 # save cover image #src

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -121,7 +121,6 @@ function compute_axes_grid(s::OneOrMoreLayers;
         end
     end
 
-    #=
     # Link colors
     labeledcolorrange = getlabeledcolorrange(axes_grid)
     if !isnothing(labeledcolorrange)
@@ -130,7 +129,6 @@ function compute_axes_grid(s::OneOrMoreLayers;
             entry.attributes[:colorrange] = colorrange
         end
     end
-=#
 
     # Axis labels and ticks
     for ae in axes_grid

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -94,7 +94,7 @@ function compute_axes_grid(s::OneOrMoreLayers;
 
     function create_axis(c)
         type = get(axis, :type, Axis)
-        options = Dict(; Base.structdiff(axis, (; type))...)
+        options = Dict(pairs(Base.structdiff(axis, (; type))))
         position = Tuple(c)
 
         return _AxisEntries_(type, position, options, Entry[], scales)

--- a/src/entries.jl
+++ b/src/entries.jl
@@ -46,6 +46,27 @@ struct AxisEntries
     scales::Dict{KeyType, Any}
 end
 
+struct _AxisEntries_
+    type::Type{<: Union{Axis, Axis3}}
+    position::Tuple{Int,Int}
+    options::Dict{KeyType, Any}
+    entries::Vector{Entry}
+    scales::Dict{KeyType, Any}
+end
+
+function AxisEntries(ae::_AxisEntries_, fig)
+    ax = ae.type(fig[ae.position...]; ae.options...)
+    AxisEntries(ax, ae.entries, ae.scales)
+end
+
+function AxisEntries(ae::_AxisEntries_, ax::Union{Axis,Axis3})
+    if !isempty(axis)
+        @warn("Axis got passed, but also axis attributes. Ignoring axis attributes $(ae.options)")
+    end
+    AxisEntries(ax, ae.entries, ae.scales)
+end
+
+
 # Slightly complex machinery to recombine stacked barplots
 function mergeable(e1::Entry, e2::Entry)
     for e in (e1, e2)
@@ -120,6 +141,7 @@ function Makie.plot!(ae::AxisEntries)
 end
 
 entries(grid::AbstractMatrix{AxisEntries}) = Iterators.flatten(ae.entries for ae in grid)
+entries(grid::AbstractMatrix{_AxisEntries_}) = Iterators.flatten(ae.entries for ae in grid)
 
 struct FigureGrid
     figure::Figure


### PR DESCRIPTION
replaces #284.

Defer the creation of the `Axis` until after the axis labels are known.

Introduce an intermediate struct `_AxisGrid_` that doesn't store an `Axis`, but the axis type, figure position and options.

![image](https://user-images.githubusercontent.com/6280307/136792085-7ac2d038-03b3-4801-b5ef-181716e0e50c.png)

see also here: http://juliaplots.org/AlgebraOfGraphics.jl/previews/PR289/gallery/gallery/data%20manipulations/new_columns_on_the_fly/#Renaming-(including-LaTeX-labels)-and-transforming-variables