### PR TITLE
Clarify docs for `visual`

### DIFF
--- a/docs/src/generated/visual.jl
+++ b/docs/src/generated/visual.jl
@@ -3,9 +3,18 @@
 # The function `visual` can be used to give data-independent visual information about the plot
 # (plotting function or attributes).
 
-# The available plotting functions are documented [here](http://makie.juliaplots.org/dev/examples/plotting_functions/).
-# Refer to plotting functions using upper CamelCase for `visual`'s first argument (e.g. `visual(Scatter), visual(BarPlot)`).
-# See the documentation of each plotting function to discover the available attributes.
+# The available plotting functions are documented
+# [here](http://makie.juliaplots.org/dev/examples/plotting_functions/). Refer to
+# plotting functions using upper CamelCase for `visual`'s first argument (e.g.
+# `visual(Scatter), visual(BarPlot)`). See the documentation of each plotting
+# function to discover the available attributes. These attributes can be passed
+# as additional keyword arguments to `visual`, or as part of the `mapping` 
+# you define.
+
+# In fact `visual` can be used for any plotting function that is defined using
+# the `@recipe` macro from Makie. This means that if you have a custom recpie
+# defined in another package you can use it from AlgebraOfGraphics just like any
+# of the plotting functions defined in Makie.
 
 ## Examples
 

--- a/docs/src/generated/visual.jl
+++ b/docs/src/generated/visual.jl
@@ -12,7 +12,7 @@
 # you define.
 
 # In fact `visual` can be used for any plotting function that is defined using
-# the `@recipe` macro from Makie. This means that if you have a custom recpie
+# the `@recipe` macro from Makie. This means that if you have a custom recipe
 # defined in another package you can use it from AlgebraOfGraphics just like any
 # of the plotting functions defined in Makie.
 


### PR DESCRIPTION
I've added some clarifications for how keyword arguments are passed (it was not obvious to me until I read the source)

I've indicated that any `@recipe` created plot function can be used with `visual`, since this was also not obvious to me until I read the source / read the response in #321 

By the way, thanks for creating this awesome package!