### PR TITLE
Fix a typo in the docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,6 +11,6 @@ This package can be installed typing
 ```julia
 julia> import Pkg; Pkg.add("AlgebraOfGraphics")
 ```
-in the julia REPL.
+in the Julia REPL.
 
 See the [Tutorial](@ref) to get started.

--- a/docs/src/layers/introduction.md
+++ b/docs/src/layers/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Layers are the key building block of AlgebraOfGraphics.
+Layers are the key building blocks of AlgebraOfGraphics.
 Each layer is the product of the following elementary objects.
 
 - [Data](@ref) (encoding the dataset).


### PR DESCRIPTION
Just fixed a typo in the documentation. 

Thank you very much for the development and maintenance of this great package!