### PR TITLE
correct width for date axis

### DIFF
--- a/docs/gallery/gallery/applications/time_series.jl
+++ b/docs/gallery/gallery/applications/time_series.jl
@@ -30,6 +30,18 @@ plt = data(df) *
     visual(Lines)
 fg = draw(plt)
 
+#
+
+dates = Date(2022, 1, 1):Day(1):Date(2022, 1, 31)
+trend = cumsum(randn(31))
+df = map(1:2000) do _
+    idx = rand(1:31)
+    date = dates[idx]
+    observation = trend[idx] + 2 * rand()
+    return (; date, observation)
+end
+plt = data(df) * mapping(:date, :observation) * visual(BoxPlot)
+draw(plt)
 
 # save cover image #src
 mkpath("assets") #src

--- a/src/AlgebraOfGraphics.jl
+++ b/src/AlgebraOfGraphics.jl
@@ -7,7 +7,7 @@ using StructArrays: StructArrays, components, uniquesorted, GroupPerm, StructArr
 using GeometryBasics: AbstractGeometry, Polygon, MultiPolygon
 using GeoInterface: coordinates, geotype
 using Colors: RGB, RGBA, red, green, blue, Color
-using PlotUtils: optimize_datetime_ticks, AbstractColorList
+using PlotUtils: AbstractColorList
 using Makie
 using Makie: current_default_theme, to_value, automatic, Automatic, PlotFunc, ATTRIBUTES
 import Makie.MakieLayout: hidexdecorations!,

--- a/src/algebra/layer.jl
+++ b/src/algebra/layer.jl
@@ -258,10 +258,15 @@ function compute_attributes(pl::ProcessedLayer,
 
     # avoid automatic bar width computation in Makie (issue #277)
     # sensible default for dates (isse #369)
-    # TODO: consider only doing this for categorical scale or dates
+    # TODO: consider only doing this for categorical scales or dates
     if (plottype <: Union{BarPlot, BoxPlot, CrossBar, Violin}) && !haskey(attrs, :width)
         xscale = get(continuousscales, 1, nothing)
-        width = isnothing(xscale) ? 1 : oneunit(last(xscale.extrema) - first(xscale.extrema))
+        width = if isnothing(xscale)
+            1
+        else
+            @show min, max = xscale.extrema
+            elementwise_rescale(oneunit(max - min))
+        end
         insert!(attrs, :width, width)
     end
 

--- a/src/algebra/layer.jl
+++ b/src/algebra/layer.jl
@@ -264,7 +264,7 @@ function compute_attributes(pl::ProcessedLayer,
         width = if isnothing(xscale)
             1
         else
-            @show min, max = xscale.extrema
+            min, max = xscale.extrema
             elementwise_rescale(oneunit(max - min))
         end
         insert!(attrs, :width, width)

--- a/src/algebra/layer.jl
+++ b/src/algebra/layer.jl
@@ -226,7 +226,7 @@ end
 ## Attribute processing
 
 """
-    compute_attributes(pl::ProcessedLayer)
+    compute_attributes(pl::ProcessedLayer, categoricalscales, continuousscales_grid, continuousscales)
 
 Process attributes of a `ProcessedLayer`. In particular,
 - remove AlgebraOfGraphics-specific layout attributes,
@@ -235,7 +235,10 @@ Process attributes of a `ProcessedLayer`. In particular,
 - customize behavior of bar `width` (default to `1` when not specified).
 Return computed attributes.
 """
-function compute_attributes(pl::ProcessedLayer)
+function compute_attributes(pl::ProcessedLayer,
+                            categoricalscales::MixedArguments,
+                            continuousscales_grid::AbstractMatrix,
+                            continuousscales::MixedArguments)
     plottype, primary, named, attributes = pl.plottype, pl.primary, pl.named, pl.attributes
 
     attrs = NamedArguments()
@@ -254,8 +257,19 @@ function compute_attributes(pl::ProcessedLayer)
     merge!(attrs, Dictionary(valid_options(; color, cycle)))
 
     # avoid automatic bar width computation in Makie (issue #277)
-    # TODO: consider only implementing this when `x` is categorical
-    (plottype <: BarPlot) && !haskey(attrs, :width) && insert!(attrs, :width, 1)
+    # sensible default for dates (isse #369)
+    # TODO: consider only doing this for categorical scale or dates
+    if (plottype <: Union{BarPlot, BoxPlot, CrossBar, Violin}) && !haskey(attrs, :width)
+        xscale = get(continuousscales, 1, nothing)
+        width = isnothing(xscale) ? 1 : oneunit(last(xscale.extrema) - first(xscale.extrema))
+        insert!(attrs, :width, width)
+    end
+
+    # Match colorrange extrema
+    # TODO: respect user-passed colorrange
+    # TODO: might need to change to support temporal color scale
+    colorscale = get(continuousscales, :color, nothing)
+    !isnothing(colorscale) && set!(attrs, :colorrange, colorscale.extrema)
 
     # remove unnecessary information 
     return filterkeys(!in((:col, :row, :layout, :alpha)), attrs)

--- a/src/algebra/layer.jl
+++ b/src/algebra/layer.jl
@@ -273,6 +273,7 @@ function compute_attributes(pl::ProcessedLayer,
     # Match colorrange extrema
     # TODO: respect user-passed colorrange
     # TODO: might need to change to support temporal color scale
+    # TODO: maybe use plottype to infer whether this should be passed or not
     colorscale = get(continuousscales, :color, nothing)
     !isnothing(colorscale) && set!(attrs, :colorrange, colorscale.extrema)
 

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -78,6 +78,11 @@ const time_offset = let startingdate = Date(2020, 01, 01)
     ms / Millisecond(1)
 end
 
+function datetime2float(x::Period)
+    ms:: Millisecond = x
+    return ms / Millisecond(1)
+end
+
 function datetime2float(x::TimeType)
     ms::Millisecond = DateTime(x)
     return ms / Millisecond(1) - time_offset
@@ -104,7 +109,7 @@ function datetimeticks(f, datetimes::AbstractVector{<:TimeType})
 end
 
 # Rescaling methods that do not depend on context
-elementwise_rescale(value::TimeType) = datetime2float(value) 
+elementwise_rescale(value::Union{TimeType, Period}) = datetime2float(value) 
 elementwise_rescale(value::Verbatim) = value[]
 elementwise_rescale(value) = value
 

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -169,9 +169,10 @@ function optimal_datetime_range((x_min, x_max)::NTuple{2, T}; k_min=2, k_max=5) 
 end
 
 function format_datetimes(datetimes::AbstractVector{DateTime})
-    dates = Date.(datetimes)
-    timetype = dates == datetimes ? Date : isequal(extrema(dates)...) ? Time : DateTime
-    return string.(timetype.(datetimes))
+    dates, times = Date.(datetimes), Time.(datetimes)
+    (dates == datetimes) && return string.(dates)
+    isequal(extrema(dates)...) && return string.(times)
+    return string.(datetimes)
 end
 
 format_datetimes(datetimes::AbstractVector) = string.(datetimes)

--- a/src/scales.jl
+++ b/src/scales.jl
@@ -157,7 +157,7 @@ temporal_resolutions(::Type{Date}) = (Year, Month, Day)
 temporal_resolutions(::Type{Time}) = (Hour, Minute, Second, Millisecond)
 temporal_resolutions(::Type{DateTime}) = (temporal_resolutions(Date)..., temporal_resolutions(Time)...)
 
-function optimal_datetime_range((x_min, x_max)::NTuple{2, T}; k_min=2, k_max=5) where {T}
+function optimal_datetime_range((x_min, x_max)::NTuple{2, T}; k_min=2, k_max=5) where {T<:TimeType}
     local P, start, stop
     for outer P in temporal_resolutions(T)
         start, stop = trunc(x_min, P), trunc(x_max, P)
@@ -168,12 +168,17 @@ function optimal_datetime_range((x_min, x_max)::NTuple{2, T}; k_min=2, k_max=5) 
     return start:P(1):stop
 end
 
+function format_datetimes(datetimes::AbstractVector{DateTime})
+    dates = Date.(datetimes)
+    timetype = dates == datetimes ? Date : isequal(extrema(dates)...) ? Time : DateTime
+    return string.(timetype.(datetimes))
+end
+
+format_datetimes(datetimes::AbstractVector) = string.(datetimes)
+
 function ticks(limits::NTuple{2, TimeType})
     datetimes = optimal_datetime_range(limits)
-    dates = map(Date, datetimes)
-    timetype = dates == datetimes ? Date : isequal(extrema(dates)...) ? Time : DateTime
-    labels = string.(timetype.(datetimes))
-    return datetime2float.(datetimes), labels
+    return datetime2float.(datetimes), format_datetimes(datetimes)
 end
 
 @enum ScientificType categorical continuous geometrical

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using AlgebraOfGraphics, Makie, Random, Statistics, Test
+using AlgebraOfGraphics, Makie, Random, Statistics, Test, Dates
 
 using AlgebraOfGraphics: Sorted
 using AlgebraOfGraphics: separate

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using AlgebraOfGraphics: Sorted
 using AlgebraOfGraphics: separate
 using AlgebraOfGraphics: midpoints
 using AlgebraOfGraphics: compute_palettes, apply_palette
-using AlgebraOfGraphics: categoricalscales, CategoricalScale, fitscale
+using AlgebraOfGraphics: categoricalscales, CategoricalScale, fitscale, datetime2float, datetimeticks
 using AlgebraOfGraphics: extrema_finite, nested_extrema_finite
 using AlgebraOfGraphics: get_layout
 using AlgebraOfGraphics: clean_facet_attributes

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -84,9 +84,9 @@ end
 
     floats, labels = datetimeticks(month, [Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
     @test labels == ["1", "3",  "5"]
-    @test floats = datetime2float.([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
+    @test floats == datetime2float.([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
 
     floats, labels = datetimeticks([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)], ["January", "March", "May"])
     @test labels == ["January", "March", "May"]
-    @test floats = datetime2float.([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
+    @test floats == datetime2float.([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
 end

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -77,6 +77,15 @@ end
     full_labels = ["2022-01-02T02:00:00", "2022-01-02T05:00:00", "2022-01-02T08:00:00", "2022-01-02T11:00:00", "2022-01-02T14:00:00"]
     @test labels == ["02:00:00", "05:00:00", "08:00:00", "11:00:00", "14:00:00"]
     @test floats == datetime2float.(DateTime.(full_labels))
+    
+    floats, labels = AlgebraOfGraphics.ticks((DateTime(2022, 1, 2, 1, 1, 5), DateTime(2022, 1, 2, 1, 1, 5)))
+    full_labels = ["2022-01-02T01:01:05"]
+    @test labels == ["01:01:05"]
+    @test floats == datetime2float.(DateTime.(full_labels))
+
+    floats, labels = AlgebraOfGraphics.ticks((Time(1, 1, 5), Time(16, 4, 28)))
+    @test labels == ["02:00:00", "05:00:00", "08:00:00", "11:00:00", "14:00:00"]
+    @test floats == datetime2float.(Time.(labels))
 
     floats, labels = AlgebraOfGraphics.ticks((DateTime(2022, 1, 2, 1, 1, 5), DateTime(2022, 1, 3, 16, 4, 28)))
     @test labels == ["2022-01-02T02:00:00", "2022-01-02T10:00:00", "2022-01-02T18:00:00", "2022-01-03T02:00:00", "2022-01-03T10:00:00"]

--- a/test/scales.jl
+++ b/test/scales.jl
@@ -64,3 +64,29 @@ end
     uv = [:a, :b, :c, :d, :e]
     @test apply_palette(p, uv) == [p[1], p[2], p[3], p[1], p[2]]
 end
+
+@testset "datetimes" begin
+    for d in [Date(2011, 9, 1), Date(2032, 5, 7), DateTime(2033, 9, 1, 3, 14, 16)]
+        @test Millisecond(datetime2float(d)) + DateTime(2020, 1, 1) == d
+    end
+    floats, labels = AlgebraOfGraphics.ticks((Date(2021, 5, 1), Date(2021, 9, 1)))
+    @test labels == ["2021-05-01", "2021-06-01", "2021-07-01", "2021-08-01", "2021-09-01"]
+    @test floats == datetime2float.(Date.(labels))
+
+    floats, labels = AlgebraOfGraphics.ticks((DateTime(2022, 1, 2, 1, 1, 5), DateTime(2022, 1, 2, 16, 4, 28)))
+    full_labels = ["2022-01-02T02:00:00", "2022-01-02T05:00:00", "2022-01-02T08:00:00", "2022-01-02T11:00:00", "2022-01-02T14:00:00"]
+    @test labels == ["02:00:00", "05:00:00", "08:00:00", "11:00:00", "14:00:00"]
+    @test floats == datetime2float.(DateTime.(full_labels))
+
+    floats, labels = AlgebraOfGraphics.ticks((DateTime(2022, 1, 2, 1, 1, 5), DateTime(2022, 1, 3, 16, 4, 28)))
+    @test labels == ["2022-01-02T02:00:00", "2022-01-02T10:00:00", "2022-01-02T18:00:00", "2022-01-03T02:00:00", "2022-01-03T10:00:00"]
+    @test floats == datetime2float.(DateTime.(labels))
+
+    floats, labels = datetimeticks(month, [Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
+    @test labels == ["1", "3",  "5"]
+    @test floats = datetime2float.([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
+
+    floats, labels = datetimeticks([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)], ["January", "March", "May"])
+    @test labels == ["January", "March", "May"]
+    @test floats = datetime2float.([Date(2022, 1, 1), Date(2022, 3, 1), Date(2022, 5, 1)])
+end


### PR DESCRIPTION
Fix #369

TODO:

- [x] Add tests for `datetime2float`, `datetimeticks` and `ticks(::NTuple{2, TimeType})`