### PR TITLE
Support incomplete list for `sorter` and `renamer`

### DIFF
--- a/docs/gallery/gallery/scales/custom_scales.jl
+++ b/docs/gallery/gallery/scales/custom_scales.jl
@@ -42,15 +42,15 @@ plt = data(df) *
     visual(Arrows, arrowsize=10, lengthscale=0.3)
 draw(plt; palettes=(arrowcolor=colors, arrowhead=heads))
 
-# To associate specific attribute values to specific data values, use pairs.
-# Missing keys will cycle over values that are not pairs.
+# To associate specific attribute values to specific data values, use `sorter` or `renamer`
 
 x = rand(100)
 y = rand(100)
 z = rand(["a", "b", "c", "d"], 100)
 df = (; x, y, z)
-plt = data(df) * mapping(:x, :y, color=:z)
-colors = ["a" => colorant"#E24A33", "c" => colorant"#348ABD", colorant"#988ED5", colorant"#777777"]
+plt = data(df) * mapping(:x, :y, color=:z => sorter("a", "c"))
+# "a" will get color #E24A33 and "c" will get #348ABD
+colors = [colorant"#E24A33", colorant"#348ABD", colorant"#988ED5", colorant"#777777"]
 draw(plt; palettes=(color=colors,))
 
 # Categorical color gradients can also be passed to `palettes`.

--- a/docs/src/layers/mapping.md
+++ b/docs/src/layers/mapping.md
@@ -82,3 +82,8 @@ The complete API of helper functions is available at [Mapping helpers](@ref).
 # column `labels` is expressed in strings and we do not want to treat it as categorical
 :labels => verbatim
 ```
+
+!!! note
+
+   Renaming/reordering helpers need not mention all values; e.g. `sorter(["medium",
+   "high"])` will order the unspecified value ("low") after "medimum" and "high".

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -96,6 +96,7 @@ function compute_axes_grid(s::OneOrMoreLayers;
     layers::Layers = s
     processedlayers = map(ProcessedLayer, layers)
 
+    # TODO: here is where I need to change how palettes are handled
     palettes = compute_palettes(palettes)
 
     categoricalscales = MixedArguments()

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -96,7 +96,6 @@ function compute_axes_grid(s::OneOrMoreLayers;
     layers::Layers = s
     processedlayers = map(ProcessedLayer, layers)
 
-    # TODO: here is where I need to change how palettes are handled
     palettes = compute_palettes(palettes)
 
     categoricalscales = MixedArguments()

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -121,11 +121,10 @@ end
     sorter(ks)
 
 Utility to reorder a categorical variable, as in `sorter(["low", "medium", "high"])`. A
-vararg method `sorter("low", "medium", "high")` is also supported. `ks` should include all
-the unique values of the categorical variable. The order of `ks` is respected in the legend.
-The sorter need not specify all values (e.g. `sorter(["low", "medium"])` will work for an
-array that includes "high"); the unspecified values will be sorted after the specified
-values in the order returned by `unique`.
+vararg method `sorter("low", "medium", "high")` is also supported. The order of `ks` is
+respected in the legend. The sorter need not specify all values (e.g. `sorter(["low",
+"medium"])` will work for an array that includes "high"); the unspecified values will be
+sorted after the specified values and will occur in the order returned by `unique`.
 
 """
 function sorter(ks::Union{AbstractArray, Tuple})

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -10,7 +10,7 @@
     @test r("a") < r("b") < r("c")
     @test r("a") == r("a")
     @test r("a") != r("b")
-    @test map(r, ["a", "a", "b", "c", "d"]) == ["A", "A", "B", "C", "d"]
+    @test map(r, ["a", "a", "b", "c", "d"]) == [Sorted(1, "A"), Sorted(1, "A"), Sorted(2, "B"), Sorted(3, "C"), Sorted(4, "d")]
 
     r̂ = renamer(["a" => "A", "b" => "B", "c" => "C"])
     @test r̂("a") == Sorted(1, "A")
@@ -35,7 +35,7 @@
     @test s("b") < s("c") < s("a")
     @test s("a") == s("a")
     @test s("a") != s("b")
-    @test map(s, ["a", "b", "c", "d"]) == ["a", "b", "c", "d"]
+    @test map(s, ["a", "b", "c", "d"]) == [Sorted(3, "a"), Sorted(1, "b"), Sorted(2, "c"), Sorted(4, "d")]
     
     ŝ = sorter(["b", "c", "a"])
     @test ŝ("a") == Sorted(3, "a")

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -10,6 +10,8 @@
     @test r("a") < r("b") < r("c")
     @test r("a") == r("a")
     @test r("a") != r("b")
+    @test map(r, ["a", "a", "b", "c", "d"]) == ["A", "A", "B", "C", "d"]
+
     r̂ = renamer(["a" => "A", "b" => "B", "c" => "C"])
     @test r̂("a") == Sorted(1, "A")
     @test r̂("b") == Sorted(2, "B")
@@ -33,6 +35,8 @@
     @test s("b") < s("c") < s("a")
     @test s("a") == s("a")
     @test s("a") != s("b")
+    @test map(s, ["a", "b", "c", "d"]) == ["a", "b", "c", "d"]
+    
     ŝ = sorter(["b", "c", "a"])
     @test ŝ("a") == Sorted(3, "a")
     @test ŝ("b") == Sorted(1, "b")


### PR DESCRIPTION
This addresses the proposal in #329 to make it possible to handle palettes a little more cleanly:

Specifically the missing piece this adds is to handle the case where sorter and renamer are provided only a partial enumeration of values.

Then, to quote @piever, the old:

```julia
# `a` and `b` entries get specified colors, for the other entries it's data-dependent
palette = (color=["a" => "red", "b" => "blue", "green", "black"],)
```

can now be achieved with


```julia
mapping(color=v => sorter(["a", "b"])
palette = (color=["red", "blue", "green", "black"],)
```