### PR TITLE
Pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/Manifest.toml
 docs/build
 docs/src/gallery
 docs/src/democards
+.vscode/settings.json

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 RelocatableFolders = "05181044-ff0b-4ac5-8273-598c1e38db00"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-TableOperations = "ab02a1b2-a7df-11e8-156e-fb1833f50b87"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 RelocatableFolders = "05181044-ff0b-4ac5-8273-598c1e38db00"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+TableOperations = "ab02a1b2-a7df-11e8-156e-fb1833f50b87"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]

--- a/docs/gallery/gallery/layout/faceting.jl
+++ b/docs/gallery/gallery/layout/faceting.jl
@@ -70,6 +70,27 @@ df = (x=rand(100), y=rand(100), l=rand([1, 2, 3, 4, 5], 100))
 plt = data(df) * mapping(:x, :y, layout=:l => nonnumeric)
 draw(plt)
 
+# ## Pagination
+#
+# If you have too many facets for one figure, you can use `paginate` to split the data into several subsets
+# given a maximum number of plots per layout, row or column.
+
+df = (x=rand(500), y=rand(500), l=rand(["a", "b", "c", "d", "e", "f", "g", "h"], 500))
+plt = data(df) * mapping(:x, :y, layout=:l)
+pag = paginate(plt, layout = 4)
+
+# The object returned from `draw` will be a `Vector{FigureGrid}`.
+
+figuregrids = draw(pag)
+
+# You can either extract single figures from this vector...
+
+figuregrid[1]
+
+# or use `draw` with an optional second argument specifying the index of the page to draw.
+
+draw(pag, 2)
+
 # save cover image #src
 mkpath("assets") #src
 save("assets/faceting.png", fg) #src

--- a/docs/gallery/gallery/layout/faceting.jl
+++ b/docs/gallery/gallery/layout/faceting.jl
@@ -85,7 +85,7 @@ figuregrids = draw(pag)
 
 # You can either extract single figures from this vector...
 
-figuregrid[1]
+figuregrids[1]
 
 # or use `draw` with an optional second argument specifying the index of the page to draw.
 

--- a/docs/gallery/gallery/layout/faceting.jl
+++ b/docs/gallery/gallery/layout/faceting.jl
@@ -75,6 +75,11 @@ draw(plt)
 # If you have too many facets for one figure, you can use `paginate` to split the data into several subsets
 # given a maximum number of plots per layout, row or column.
 
+# Note that pagination is considered an experimental feature.
+# In the current implementation, scales and layouts are not synchronized across pages.
+# This means that, e.g., linked limits on one page are not influenced by limits of other pages.
+# The exact synchronization behavior can be subject to change in non-breaking versions.
+
 df = (x=rand(500), y=rand(500), l=rand(["a", "b", "c", "d", "e", "f", "g", "h"], 500))
 plt = data(df) * mapping(:x, :y, layout=:l)
 pag = paginate(plt, layout = 4)

--- a/docs/src/API/functions.md
+++ b/docs/src/API/functions.md
@@ -7,6 +7,7 @@ draw
 draw!
 colorbar!
 legend!
+paginate
 ```
 
 ## Mapping helpers

--- a/src/AlgebraOfGraphics.jl
+++ b/src/AlgebraOfGraphics.jl
@@ -2,7 +2,7 @@ module AlgebraOfGraphics
 
 using Base: front, tail
 using Dates
-using Tables: rows, columns, getcolumn, columnnames
+using Tables: rows, columns, getcolumn, columnnames, columntable
 using StructArrays: StructArrays, components, uniquesorted, GroupPerm, StructArray
 using GeometryBasics: AbstractGeometry, Polygon, MultiPolygon
 using GeoInterface: coordinates, isgeometry, geomtrait, PolygonTrait, MultiPolygonTrait
@@ -25,6 +25,7 @@ using StatsBase: fit, histrange, Histogram, normalize, sturges, StatsBase
 import GLM, Loess
 import FileIO
 import RelocatableFolders
+import TableOperations
 
 export hideinnerdecorations!, deleteemptyaxes!
 export Layer, ProcessedLayer
@@ -36,6 +37,7 @@ export datetimeticks
 export draw, draw!
 export facet!, colorbar!, legend!
 export set_aog_theme!
+export paginate
 
 include("dict.jl")
 include("theme.jl")
@@ -62,5 +64,6 @@ include("guides/legendelements.jl")
 include("guides/legend.jl")
 include("guides/colorbar.jl")
 include("draw.jl")
+include("paginate.jl")
 
 end

--- a/src/AlgebraOfGraphics.jl
+++ b/src/AlgebraOfGraphics.jl
@@ -25,7 +25,6 @@ using StatsBase: fit, histrange, Histogram, normalize, sturges, StatsBase
 import GLM, Loess
 import FileIO
 import RelocatableFolders
-import TableOperations
 
 export hideinnerdecorations!, deleteemptyaxes!
 export Layer, ProcessedLayer

--- a/src/algebra/layer.jl
+++ b/src/algebra/layer.jl
@@ -40,6 +40,10 @@ Base.@kwdef struct ProcessedLayer
     attributes::NamedArguments=NamedArguments()
 end
 
+struct ProcessedLayers
+    layers::Vector{ProcessedLayer}
+end
+
 function ProcessedLayer(processedlayer::ProcessedLayer; kwargs...)
     nt = (;
         processedlayer.plottype,

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -78,7 +78,7 @@ function compute_palettes(palettes)
     return foldl(merge!, (layout, theme_palettes, user_palettes), init=NamedArguments())
 end
 
-function compute_axes_grid(fig, s::OneOrMoreLayers;
+function compute_axes_grid(fig, s::Union{OneOrMoreLayers, ProcessedLayers};
                            axis=NamedTuple(), palettes=NamedTuple())
 
     axes_grid = compute_axes_grid(s; axis, palettes)
@@ -92,12 +92,18 @@ function compute_axes_grid(fig, s::OneOrMoreLayers;
 end
 
 function compute_axes_grid(s::OneOrMoreLayers;
-                           axis=NamedTuple(), palettes=NamedTuple())
-    layers::Layers = s
-    processedlayers = map(ProcessedLayer, layers)
+    axis=NamedTuple(), palettes=NamedTuple())
 
+    layers::Layers = s
+    processedlayers = ProcessedLayers(map(ProcessedLayer, layers))
+    compute_axes_grid(processedlayers; axis, palettes)
+end
+
+function compute_axes_grid(p::ProcessedLayers;
+                           axis=NamedTuple(), palettes=NamedTuple())
     palettes = compute_palettes(palettes)
 
+    processedlayers = p.layers
     categoricalscales = MixedArguments()
     for processedlayer in processedlayers
         mergewith!(

--- a/src/algebra/layers.jl
+++ b/src/algebra/layers.jl
@@ -92,7 +92,7 @@ function compute_axes_grid(fig, s::Union{OneOrMoreLayers, ProcessedLayers};
 end
 
 function compute_axes_grid(s::OneOrMoreLayers;
-    axis=NamedTuple(), palettes=NamedTuple())
+                           axis=NamedTuple(), palettes=NamedTuple())
 
     layers::Layers = s
     processedlayers = ProcessedLayers(map(ProcessedLayer, layers))

--- a/src/draw.jl
+++ b/src/draw.jl
@@ -13,7 +13,7 @@ function update(f, fig)
     return output
 end
 
-function Makie.plot!(fig, s::OneOrMoreLayers;
+function Makie.plot!(fig, s::Union{OneOrMoreLayers, ProcessedLayers};
                      axis=NamedTuple(), palettes=NamedTuple())
     if isa(fig, Union{Axis, Axis3}) && !isempty(axis)
         @warn("Axis got passed, but also axis attributes. Ignoring axis attributes $axis.")
@@ -23,7 +23,7 @@ function Makie.plot!(fig, s::OneOrMoreLayers;
     return grid
 end
 
-function Makie.plot(s::OneOrMoreLayers;
+function Makie.plot(s::Union{OneOrMoreLayers, ProcessedLayers};
                     axis=NamedTuple(), figure=NamedTuple(), palettes=NamedTuple())
     fig = Figure(; figure...)
     grid = plot!(fig, s; axis, palettes)
@@ -39,7 +39,7 @@ to `figure`, or custom palettes to `palettes`.
 Legend and colorbar are drawn automatically. For finer control, use [`draw!`](@ref),
 [`legend!`](@ref), and [`colorbar!`](@ref) independently.
 """
-function draw(s::OneOrMoreLayers;
+function draw(s::Union{OneOrMoreLayers, ProcessedLayers};
               axis=NamedTuple(), figure=NamedTuple(), palettes=NamedTuple(),
               facet=NamedTuple(), legend=NamedTuple(), colorbar=NamedTuple())
     return update(Figure(; figure...)) do f
@@ -61,7 +61,7 @@ Draw a [`AlgebraOfGraphics.Layer`](@ref) or [`AlgebraOfGraphics.Layers`](@ref) o
 The output can be customized by giving axis attributes to `axis` or custom palettes
 to `palettes`.  
 """
-function draw!(fig, s::OneOrMoreLayers;
+function draw!(fig, s::Union{OneOrMoreLayers, ProcessedLayers};
                axis=NamedTuple(), palettes=NamedTuple(), facet=NamedTuple())
     return update(fig) do f
         ag = plot!(f, s; axis, palettes)

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -41,7 +41,6 @@ function paginator(layer::Layer, data, spec, limiter)
     layers = map(sets) do set
         return Layer(layer.transformation, func(set)..., layer.named)
     end
-    Main.@infiltrate
     return Paginate(layers)
 end
 
@@ -63,7 +62,6 @@ function paginator(layer::Layer, data, (row, col)::Tuple, (rows, columns)::Tuple
             layer.named,
         )
     end
-    Main.@infiltrate
     return Paginate(vec(layers))
 end
 

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -183,7 +183,3 @@ function _invert!(out, a, innerkeys, outerkeys)
     end
     return out
 end
-
-# Reshape the vector `v` to `N` axes.
-withshape(::Val{N}, v::AbstractVector) where N = reshape(v, ntuple(n -> ifelse(n < N, 1, length(v)), N))
-withshape(::AbstractArray{T,N}, v::AbstractVector) where {T,N} = withshape(Val{N}(), v)

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -1,0 +1,123 @@
+# Dispatcher type for `draw` usage.
+struct Paginate
+    each::Vector
+end
+
+draw(p::Paginate; kws...) = draw.(p.each; kws...)
+draw(p::Paginate, i::Int; kws...) = draw(p.each[i]; kws...)
+
+function getsets(layer, data, column, by)
+    func(column::Tuple) = sort!(unique(Iterators.product((getcolumn(data, c) for c in column)...)))
+    func(column) = sort!(unique(getcolumn(data, column)))
+    values = func(column)
+    parts = Iterators.partition(values, by)
+    return map(Set{eltype(values)}, parts)
+end
+
+function getsets(layer, data, dims::DimsSelector, by)
+    positional = layer.positional
+    return zip((d in dims.dims ? (withshape(p, each) for each in Iterators.partition(p, by)) : Iterators.cycle(p) for (d, p) in enumerate(positional))...)
+end
+
+colname((name, _)::Pair) = name
+colname(name) = name
+
+getcols(row, name) = getcolumn(row, name)
+getcols(row, name::Tuple) = map(n -> getcolumn(row, n), name)
+
+function paginator(layer::Layer, data, spec, limiter)
+    name = colname(spec)
+    sets = getsets(layer, data, name, limiter)
+
+    function func(set::Set)
+        table = TableOperations.filter(data) do row
+            value = getcols(row, name)
+            return value in set
+        end
+        return columntable(table), layer.positional
+    end
+    func(positional::Tuple) = (layer.data, positional)
+
+    layers = map(sets) do set
+        return Layer(layer.transformation, func(set)..., layer.named)
+    end
+    Main.@infiltrate
+    return Paginate(layers)
+end
+
+function paginator(layer::Layer, data, (row, col)::Tuple, (rows, columns)::Tuple)
+    row_name = colname(row)
+    col_name = colname(col)
+    row_sets = getsets(layer, data, row_name, rows)
+    col_sets = getsets(layer, data, col_name, columns)
+    layers = map(Iterators.product(row_sets, col_sets)) do (row_set, col_set)
+        table = TableOperations.filter(data) do row
+            row_value = getcols(row, row_name)
+            col_value = getcols(row, col_name)
+            return row_value in row_set && col_value in col_set
+        end
+        return Layer(
+            layer.transformation,
+            columntable(table),
+            layer.positional,
+            layer.named,
+        )
+    end
+    Main.@infiltrate
+    return Paginate(vec(layers))
+end
+
+"""
+    paginate(layers; limit, rows, columns)
+Paginate the layer objects created by an `AlgebraOfGraphics` spec to create a
+vector of layers that each operate on a subset of the input data. Can be passed
+through to `draw` which will return a `Vector` of figures rather than a single
+figure.
+The following keywords must be combined to create suitable paginations:
+  - `limit` and `layout` or,
+  - `rows` and `row` and/or,
+  - `columns` and `col`
+"""
+function paginate end
+
+function paginate(
+        layer::Layer;
+        limit = nothing,
+        rows = nothing,
+        columns = nothing,
+    )
+    named = layer.named
+    data = layer.data
+
+    layout = get(named, :layout, nothing)
+    row = get(named, :row, nothing)
+    col = get(named, :col, nothing)
+
+    valid(a, b) = !isnothing(a) && !isnothing(b)
+
+    if valid(layout, limit)
+        return paginator(layer, data, layout, limit)
+    elseif valid(row, rows) && valid(col, columns)
+        return paginator(layer, data, (row, col), (rows, columns))
+    elseif valid(row, rows)
+        return paginator(layer, data, row, rows)
+    elseif valid(col, columns)
+        return paginator(layer, data, col, columns)
+    else
+        return Paginate([layer])
+    end
+end
+
+function paginate(
+        layers::Layers;
+        limit = nothing,
+        rows = nothing,
+        columns = nothing,
+    )
+    inverted = [paginate(layer; limit, rows, columns).each for layer in layers]
+    return Paginate(Layers.(SplitApplyCombine.invert(inverted)))
+end
+
+# Reshape the vector `v` to `N` axes.
+withshape(::Val{N}, v::AbstractVector) where N = reshape(v, ntuple(n -> ifelse(n < N, 1, length(v)), N))
+withshape(::AbstractArray{T,N}, v::AbstractVector) where {T,N} = withshape(Val{N}(), v)

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -60,7 +60,7 @@ colname(name) = name
 getcols(row, name) = getcolumn(row, name)
 getcols(row, name::Tuple) = map(n -> getcolumn(row, n), name)
 
-function paginate_layer(layer::ProcessedLayer; layout = nothing, row = nothing, col = nothing)
+function paginate_layer(layer::ProcessedLayer; layout=nothing, row=nothing, col=nothing)
     primary = layer.primary
 
     layout_data = get(primary, :layout, nothing)
@@ -105,7 +105,7 @@ function paginate_layer(layer::ProcessedLayer, data_limiter_pairs::Pair...)
 end
 
 """
-    paginate(l; layout = nothing, row = nothing, col = nothing)
+    paginate(l; layout=nothing, row=nothing, col=nothing)
 
 Paginate `l`, the `Layer` or `Layers` object created by an `AlgebraOfGraphics` spec, to create a
 `PaginatedLayers` object.

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -79,7 +79,7 @@ function paginate_layer(layer::Layer; layout = nothing, row = nothing, col = not
     elseif valid(rowspec, row)
         paginate_layer(layer, data, rowspec, row)
     elseif valid(col, col)
-        paginate_layer(layer, data, col, col)
+        paginate_layer(layer, data, colspec, col)
     else
         [layer]
     end

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -13,10 +13,11 @@ function Base.show(io::IO, p::PaginatedLayers)
         !isnothing ∘ last,
         [key => getfield(p, key) for key in (:layout, :row, :col)]
     )
-    _info_str = join(("$key = $value" for (key, value) in _info), ", ")
+    _info_str = isempty(_info) ? "no limits set" :
+        join(("$key = $value" for (key, value) in _info), ", ")
     n = length(p)
     entry_str = n == 1 ? "1 entry" : "$n entries"
-    print(io, "PaginatedLayers with $entry_str ($(isempty(_info_str) ? "no limits set" : _info_str))")
+    print(io, "PaginatedLayers with $entry_str ($_info_str)")
 end
 
 """

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -36,7 +36,12 @@ Keywords `kws` are passed to the underlying `draw` call.
 
 You can retrieve the number of elements using `length(p)`.
 """
-draw(p::PaginatedLayers, i::Int; kws...) = draw(p.each[i]; kws...)
+function draw(p::PaginatedLayers, i::Int; kws...)
+    if i ∉ 1:length(p)
+        throw(ArgumentError("Invalid index $i for PaginatedLayers with $(length(p)) entries."))
+    end
+    draw(p.each[i]; kws...)
+end
 
 function getsets(layer, data, column, by)
     func(column::Tuple) = sort!(unique(Iterators.product((getcolumn(data, c) for c in column)...)))

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -8,16 +8,33 @@ end
 
 Base.length(p::PaginatedLayers) = length(p.each)
 
-function show(io::IO, p::PaginatedLayers)
+function Base.show(io::IO, p::PaginatedLayers)
     _info = filter(
         !isnothing ∘ last,
         [key => getfield(p, key) for key in (:layout, :row, :col)]
     )
     _info_str = join(("$key = $value" for (key, value) in _info), ", ")
-    print(io, "PaginatedLayers with $(length(p)) entries ($(isempty(_info_str) ? "no limits" : _info_str))")
+    n = length(p)
+    entry_str = n == 1 ? "1 entry" : "$n entries"
+    print(io, "PaginatedLayers with $entry_str ($(isempty(_info_str) ? "no limits set" : _info_str))")
 end
 
+"""
+    draw(p::PaginatedLayerskws...)
+
+Draw each element of `PaginatedLayers` `p` and return a `Vector{FigureGrid}`.
+Keywords `kws` are passed to the underlying `draw` calls.
+"""
 draw(p::PaginatedLayers; kws...) = draw.(p.each; kws...)
+
+"""
+    draw(p::PaginatedLayers, i::Int; kws...)
+
+Draw the ith element of `PaginatedLayers` `p` and return a `FigureGrid`.
+Keywords `kws` are passed to the underlying `draw` call.
+
+You can retrieve the number of elements using `length(p)`.
+"""
 draw(p::PaginatedLayers, i::Int; kws...) = draw(p.each[i]; kws...)
 
 function getsets(layer, data, column, by)
@@ -110,7 +127,7 @@ function paginate(
     layers = if valid(layoutspec, layout)
         paginate_layer(layer, data, layoutspec, layout)
     elseif valid(rowspec, row) && valid(colspec, col)
-        paginate_layer(layer, data, (rowspec, col), (rowspec, col))
+        paginate_layer(layer, data, (rowspec, colspec), (row, col))
     elseif valid(rowspec, row)
         paginate_layer(layer, data, rowspec, row)
     elseif valid(col, col)

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -97,15 +97,39 @@ function paginate_layer(layer::Layer, data, (row, col)::Tuple, (rows, columns)::
 end
 
 """
-    paginate(layers; limit, rows, columns)
-PaginatedLayers the layer objects created by an `AlgebraOfGraphics` spec to create a
-vector of layers that each operate on a subset of the input data. Can be passed
-through to `draw` which will return a `Vector` of figures rather than a single
-figure.
-The following keywords must be combined to create suitable paginations:
-  - `limit` and `layout` or,
-  - `rows` and `row` and/or,
-  - `columns` and `col`
+    paginate(layers; layout, row, col)
+
+Paginate the `Layer` or `Layers` object created by an `AlgebraOfGraphics` spec to create a
+`PaginatedLayers` object.
+This contains a vector of layers where each layer operates on a subset of the input data.
+
+The `PaginatedLayers` object can be passed to `draw` which will return a `Vector{FigureGrid}`
+rather than a single figure.
+
+The keywords that limit the number of subplots on each page are the same that are used
+to specify facets in `mapping`:
+  - `layout`: Maximum number of subplots in a wrapped linear layout.
+  - `row`: Maximum number of rows in a 2D layout.
+  - `col`: Maximum number of columns in a 2D layout.
+
+## Example
+
+```
+d = data((
+    x = rand(1000),
+    y = rand(1000),
+    group1 = rand(string.('a':'i'), 1000),
+    group2 = rand(string.('j':'r'), 1000),
+))
+
+layer_1 = d * mapping(:x, :y, layout = :group1) * visual(Scatter)
+paginated_1 = paginate(layer_1, layout = 9)
+figuregrids = draw(paginated_1)
+
+layer_2 = d * mapping(:x, :y, row = :group1, col = :group2) * visual(Scatter)
+paginated_2 = paginate(layer_2, row = 4, col = 3)
+figuregrid = draw(paginated_2, 1) # draw only the first grid
+```
 """
 function paginate end
 

--- a/src/paginate.jl
+++ b/src/paginate.jl
@@ -152,34 +152,8 @@ function paginate(
     return PaginatedLayers(layers, layout, row, col)
 end
 
-# copied from SplitApplyCombine.jl to avoid full dependency 
-function invert(a::AbstractArray{T}) where {T <: AbstractArray}
+function invert(a::AbstractArray{<:AbstractArray})
     f = first(a)
-    innersize = size(a)
-    outersize = size(f)
-    innerkeys = keys(a)
-    outerkeys = keys(f)
-
-    @boundscheck for x in a
-        if size(x) != outersize
-            error("keys don't match")
-        end
-    end
-
-    out = Array{Array{eltype(T),length(innersize)}}(undef, outersize)
-    @inbounds for i in outerkeys
-        out[i] = Array{eltype(T)}(undef, innersize)
-    end
-
-    return _invert!(out, a, innerkeys, outerkeys)
-end
-
-function _invert!(out, a, innerkeys, outerkeys)
-    @inbounds for i ∈ innerkeys
-        tmp = a[i]
-        for j ∈ outerkeys
-            out[j][i] = tmp[j]
-        end
-    end
-    return out
+    all(axes(v) == axes(f) for v in a) || error("keys don't match")
+    map(i -> [v[i] for v in a], keys(f))
 end

--- a/test/paginate.jl
+++ b/test/paginate.jl
@@ -37,9 +37,13 @@
         @test length(pag) == 10
         pag = paginate(spec, row = 10, col = 1)
         @test length(pag) == 10
-        pag = paginate(spec, row = 3, col = 3)
-        @test length(pag) == 16
         pag = paginate(spec, row = 10, col = 10)
         @test length(pag) == 1
+        pag = paginate(spec, row = 3, col = 3)
+        @test length(pag) == 16
+        pag = paginate(spec, row = 5)
+        @test length(pag) == 2
+        pag = paginate(spec, col = 5)
+        @test length(pag) == 2
     end
 end

--- a/test/paginate.jl
+++ b/test/paginate.jl
@@ -1,0 +1,45 @@
+@testset "paginate" begin
+    d = (
+        a = 1:100,
+        b = 101:200,
+        c = repeat(string.(1:10), 10),
+        d = repeat(string.('a':'j'), inner = 10)
+    )
+
+    for vis in [visual(Scatter), visual(Scatter) + visual(Lines)]
+        spec = data(d) * mapping(:a, :b, layout = :c) * vis
+        pag = paginate(spec)
+        @test length(pag) == 1
+        pag = paginate(spec, layout = 10)
+        @test length(pag) == 1
+        pag = paginate(spec, layout = 1)
+        @test length(pag) == 10
+        pag = paginate(spec, layout = 2)
+        @test length(pag) == 5
+        pag = paginate(spec, layout = 3)
+        @test length(pag) == 4
+        pag = paginate(spec, layout = 4)
+        @test length(pag) == 3
+        
+        fgrids = draw(pag)
+        @test fgrids isa Vector{FigureGrid}
+        @test length(fgrids) == length(pag)
+        for i in 1:length(pag)
+            @test draw(pag, 1) isa FigureGrid
+        end
+        @test_throws ArgumentError draw(pag, 0)
+        @test_throws ArgumentError draw(pag, length(pag) + 1)
+
+        spec = data(d) * mapping(:a, :b, row = :c, col = :d) * vis
+        pag = paginate(spec)
+        @test length(pag) == 1
+        pag = paginate(spec, row = 1, col = 10)
+        @test length(pag) == 10
+        pag = paginate(spec, row = 10, col = 1)
+        @test length(pag) == 10
+        pag = paginate(spec, row = 3, col = 3)
+        @test length(pag) == 16
+        pag = paginate(spec, row = 10, col = 10)
+        @test length(pag) == 1
+    end
+end

--- a/test/paginate.jl
+++ b/test/paginate.jl
@@ -1,9 +1,28 @@
+function _equal(l1::Layer, l2::Layer)
+    all(fieldnames(Layer)) do n
+        getproperty(l1, n) == getproperty(l2, n)
+    end
+end
+
+function _equal(l1::Layers, l2::Layers)
+    length(l1.layers) == length(l2.layers) || return false
+    all(zip(l1.layers, l2.layers)) do (l1l, l2l)
+        _equal(l1l, l2l)
+    end
+end
+
+_to_layers(l::Layers) = l
+_to_layers(l::Layer) = Layers([l])
+
 @testset "paginate" begin
+    cs = string.(0:9)
+    ds = string.('a':'j')
+
     d = (
         a = 1:100,
         b = 101:200,
-        c = repeat(string.(1:10), 10),
-        d = repeat(string.('a':'j'), inner = 10)
+        c = repeat(cs, 10),
+        d = repeat(ds, inner = 10)
     )
 
     for vis in [visual(Scatter), visual(Scatter) + visual(Lines)]
@@ -45,5 +64,40 @@
         @test length(pag) == 2
         pag = paginate(spec, col = 5)
         @test length(pag) == 2
+
+        # manually test that a spec built like a pagination is equivalent
+        # to the output of the pagination
+        pag = paginate(spec, row = 3, col = 4)
+
+        c_parts = collect(Iterators.partition(cs, 3))
+        d_parts = collect(Iterators.partition(ds, 4))
+        @test length(c_parts) * length(d_parts) == length(pag.each)
+        for (id, _ds) in enumerate(d_parts)
+            # rows change faster
+            for (ic, _cs) in enumerate(c_parts)
+                idcs = (d.c .∈ Ref(_cs)) .&  (d.d .∈ Ref(_ds))
+                # filter out all data not on the current page
+                subset = (a = d.a[idcs], b = d.b[idcs], c = d.c[idcs], d = d.d[idcs])
+                manual_pagination = data(subset) * mapping(:a, :b, row = :c, col = :d) * vis
+                manual_pagination = _to_layers(manual_pagination)
+                i = ic + length(c_parts) * (id - 1)
+                @test _equal(manual_pagination, pag.each[i])
+            end
+        end
+
+        # and once more for layout
+        spec = data(d) * mapping(:a, :b, layout = :c) * vis
+        pag = paginate(spec, layout = 3)
+
+        c_parts = collect(Iterators.partition(cs, 3))
+        @test length(c_parts) == length(pag.each)
+        for (ic, _cs) in enumerate(c_parts)
+            idcs = d.c .∈ Ref(_cs)
+            # filter out all data not on the current page
+            subset = (a = d.a[idcs], b = d.b[idcs], c = d.c[idcs], d = d.d[idcs])
+            manual_pagination = data(subset) * mapping(:a, :b, layout = :c) * vis
+            manual_pagination = _to_layers(manual_pagination)
+            @test _equal(manual_pagination, pag.each[ic])
+        end
     end
 end

--- a/test/paginate.jl
+++ b/test/paginate.jl
@@ -1,18 +1,18 @@
-function _equal(l1::Layer, l2::Layer)
-    all(fieldnames(Layer)) do n
+function _equal(l1::ProcessedLayer, l2::ProcessedLayer)
+    all(fieldnames(ProcessedLayer)) do n
         getproperty(l1, n) == getproperty(l2, n)
     end
 end
 
-function _equal(l1::Layers, l2::Layers)
+function _equal(l1::ProcessedLayers, l2::ProcessedLayers)
     length(l1.layers) == length(l2.layers) || return false
     all(zip(l1.layers, l2.layers)) do (l1l, l2l)
         _equal(l1l, l2l)
     end
 end
 
-_to_layers(l::Layers) = l
-_to_layers(l::Layer) = Layers([l])
+_to_processed_layers(l::Layers) = ProcessedLayers(map(ProcessedLayer, l.layers))
+_to_processed_layers(l::Layer) = ProcessedLayers([ProcessedLayer(l)])
 
 @testset "paginate" begin
     cs = string.(0:9)
@@ -80,7 +80,7 @@ _to_layers(l::Layer) = Layers([l])
                 # filter out all data not on the current page
                 subset = (a = d.a[idcs], b = d.b[idcs], c = d.c[idcs], d = d.d[idcs])
                 manual_pagination = data(subset) * mapping(:a, :b, row = :c, col = :d) * vis
-                manual_pagination = _to_layers(manual_pagination)
+                manual_pagination = _to_processed_layers(manual_pagination)
                 i = ic + length(c_parts) * (id - 1)
                 @test _equal(manual_pagination, pag.each[i])
             end
@@ -97,7 +97,7 @@ _to_layers(l::Layer) = Layers([l])
             # filter out all data not on the current page
             subset = (a = d.a[idcs], b = d.b[idcs], c = d.c[idcs], d = d.d[idcs])
             manual_pagination = data(subset) * mapping(:a, :b, layout = :c) * vis
-            manual_pagination = _to_layers(manual_pagination)
+            manual_pagination = _to_processed_layers(manual_pagination)
             @test _equal(manual_pagination, pag.each[ic])
         end
     end

--- a/test/paginate.jl
+++ b/test/paginate.jl
@@ -25,6 +25,7 @@ _to_layers(l::Layer) = Layers([l])
         d = repeat(ds, inner = 10)
     )
 
+    # test both Layer and Layers
     for vis in [visual(Scatter), visual(Scatter) + visual(Lines)]
         spec = data(d) * mapping(:a, :b, layout = :c) * vis
         pag = paginate(spec)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ using AlgebraOfGraphics: col_labels!, row_labels!, panel_labels!, span_xlabel!, 
 using AlgebraOfGraphics: compute_axes_grid
 using AlgebraOfGraphics: Arguments, MixedArguments, NamedArguments
 using AlgebraOfGraphics: FigureGrid
+using AlgebraOfGraphics: Layer, Layers
 
 using Makie: automatic
 using GridLayoutBase: Protrusion

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ using AlgebraOfGraphics: col_labels!, row_labels!, panel_labels!, span_xlabel!, 
 using AlgebraOfGraphics: compute_axes_grid
 using AlgebraOfGraphics: Arguments, MixedArguments, NamedArguments
 using AlgebraOfGraphics: FigureGrid
-using AlgebraOfGraphics: Layer, Layers
+using AlgebraOfGraphics: Layer, Layers, ProcessedLayer, ProcessedLayers
 
 using Makie: automatic
 using GridLayoutBase: Protrusion

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ using AlgebraOfGraphics: consistent_xlabels, consistent_ylabels, colwise_consist
 using AlgebraOfGraphics: col_labels!, row_labels!, panel_labels!, span_xlabel!, span_ylabel!
 using AlgebraOfGraphics: compute_axes_grid
 using AlgebraOfGraphics: Arguments, MixedArguments, NamedArguments
+using AlgebraOfGraphics: FigureGrid
 
 using Makie: automatic
 using GridLayoutBase: Protrusion
@@ -35,3 +36,4 @@ include("helpers.jl")
 include("facet.jl")
 include("legend.jl")
 include("geometry.jl")
+include("paginate.jl")


### PR DESCRIPTION
This PR adds pagination as discussed in https://github.com/JuliaPlots/AlgebraOfGraphics.jl/issues/303.

The approach is pretty much what @MichaelHatherly detailed in that post, I made some smaller changes and added tests and docs. Layer objects are split into groups depending on the maximum number of rows/columns/wrapped facets allowed and therefore `draw` returns a `Vector{FigureGrid}`. There's also a `draw(paginated, i)` method in case not all figures should live in memory at the same time, this method returns a `FigureGrid` accordingly.